### PR TITLE
Slash sd penalty fixes

### DIFF
--- a/contracts/SDCollateral.sol
+++ b/contracts/SDCollateral.sol
@@ -125,6 +125,9 @@ contract SDCollateral is ISDCollateral, Initializable, AccessControlUpgradeable,
     function slashSD(address _operator, uint256 _sdToSlash) internal returns (uint256 _sdSlashed) {
         uint256 sdBalance = operatorSDBalance[_operator];
         _sdSlashed = Math.min(_sdToSlash, sdBalance);
+        if (_sdSlashed == 0) {
+            return 0;
+        }
         operatorSDBalance[_operator] -= _sdSlashed;
         totalSDCollateral -= _sdSlashed;
         IAuction(staderConfig.getAuctionContract()).createLot(_sdSlashed);

--- a/contracts/ValidatorWithdrawalVault.sol
+++ b/contracts/ValidatorWithdrawalVault.sol
@@ -77,7 +77,7 @@ contract ValidatorWithdrawalVault is
         emit DistributedRewards(userShare, operatorShare, protocolShare);
     }
 
-    function settleFunds() external override nonReentrant {
+    function settleFunds() external override nonReentrant returns (uint256 _sdSlashed) {
         if (!isWithdrawnValidator() || vaultSettleStatus) {
             revert ValidatorNotWithdrawnOrSettled();
         }
@@ -86,7 +86,7 @@ contract ValidatorWithdrawalVault is
         uint256 penaltyAmount = getPenaltyAmount();
 
         if (operatorShare < penaltyAmount) {
-            ISDCollateral(staderConfig.getSDCollateral()).slashValidatorSD(validatorId, poolId);
+            _sdSlashed = ISDCollateral(staderConfig.getSDCollateral()).slashValidatorSD(validatorId, poolId);
             penaltyAmount = operatorShare;
         }
 

--- a/contracts/interfaces/IValidatorWithdrawalVault.sol
+++ b/contracts/interfaces/IValidatorWithdrawalVault.sol
@@ -21,7 +21,7 @@ interface IValidatorWithdrawalVault {
     // methods
     function distributeRewards() external;
 
-    function settleFunds() external;
+    function settleFunds() external returns (uint256 _sdSlashed);
 
     // setters
     function updateStaderConfig(address _staderConfig) external;


### PR DESCRIPTION
minor changes to use the `sdSlashed` variable returned by `slashSD` method