### PR TITLE
pool selection fix

### DIFF
--- a/contracts/StaderStakePoolsManager.sol
+++ b/contracts/StaderStakePoolsManager.sol
@@ -224,7 +224,7 @@ contract StaderStakePoolsManager is
             IUserWithdrawalManager(staderConfig.getUserWithdrawManager()).ethRequestedForWithdraw()
         );
         if (availableETHForNewDeposit == 0) {
-            revert NoETHForNewDeposit();
+            revert InsufficientBalance();
         }
         (uint256[] memory selectedPoolCapacity, uint8[] memory poolIdArray) = IPoolSelector(
             staderConfig.getPoolSelector()

--- a/contracts/interfaces/IStaderStakePoolManager.sol
+++ b/contracts/interfaces/IStaderStakePoolManager.sol
@@ -9,7 +9,6 @@ interface IStaderStakePoolManager {
     error InsufficientBalance();
     error TransferFailed();
     error PoolIdDoesNotExit();
-    error NoETHForNewDeposit();
     error CooldownNotComplete();
     error UnsupportedOperationInSafeMode();
 


### PR DESCRIPTION
- Adding trySub in deposit Logic.
- reverting if available ETH is 0 for depositETHOverTargetWeight
- Ensuring that the number of validators picked is the minimum of 
Math.min(poolAllocationMaxSize, _newValidatorToRegister, remainingPoolCapacity, remainingPoolTarget);

- First is the maximum number of validators that can be deposited in 1 tx.
- Second is the maximum number of validators that the current ETH in the deposit pool can spin up.
- Third is the maximum number of validators the queued-up validators can support (from the pool)
- Fourth is the maximum number of validators that can be spun up within limits of pool weights.