### PR TITLE
block number fix in POR feed response

### DIFF
--- a/contracts/StaderOracle.sol
+++ b/contracts/StaderOracle.sol
@@ -643,12 +643,11 @@ contract StaderOracle is IStaderOracle, AccessControlUpgradeable, PausableUpgrad
             uint256
         )
     {
-        (, int256 totalETHBalanceInInt, , uint256 ethPORUpdatedAt, ) = AggregatorV3Interface(
-            staderConfig.getETHBalancePORFeedProxy()
-        ).latestRoundData();
+        (, int256 totalETHBalanceInInt, , , ) = AggregatorV3Interface(staderConfig.getETHBalancePORFeedProxy())
+            .latestRoundData();
         (, int256 totalETHXSupplyInInt, , , ) = AggregatorV3Interface(staderConfig.getETHXSupplyPORFeedProxy())
             .latestRoundData();
-        return (uint256(totalETHBalanceInInt), uint256(totalETHXSupplyInInt), ethPORUpdatedAt);
+        return (uint256(totalETHBalanceInInt), uint256(totalETHXSupplyInInt), block.number);
     }
 
     function updateWithInLimitER(


### PR DESCRIPTION
- fixed the block number to set as reportingBlock number in ER struct for chainlink fee
- using block.number as reporting block 