### PR TITLE
remove unused struct

### DIFF
--- a/contracts/interfaces/SDCollateral/ISDCollateral.sol
+++ b/contracts/interfaces/SDCollateral/ISDCollateral.sol
@@ -11,11 +11,6 @@ interface ISDCollateral {
         string units;
     }
 
-    struct WithdrawRequestInfo {
-        uint256 lastWithdrawReqTimestamp;
-        uint256 totalSDWithdrawReqAmount;
-    }
-
     // errors
     error InsufficientSDToWithdraw(uint256 operatorSDCollateral);
     error InvalidPoolId();


### PR DESCRIPTION
SD Collateral withdraw remove time-delay.
have already updated the comments on `withdraw`
missed to remove struct. Removed in this PR.