### PR TITLE
reward address change and unit tests

### DIFF
--- a/contracts/PermissionedNodeRegistry.sol
+++ b/contracts/PermissionedNodeRegistry.sol
@@ -426,7 +426,7 @@ contract PermissionedNodeRegistry is
     /**
      * @notice update the name of an operator
      * @dev only operator msg.sender can update
-     * @param _operatorName new Name of the operator
+     * @param _operatorName new name of the operator
      */
     function updateOperatorName(string calldata _operatorName) external override {
         IPoolUtils(staderConfig.getPoolUtils()).onlyValidName(_operatorName);

--- a/contracts/PermissionedNodeRegistry.sol
+++ b/contracts/PermissionedNodeRegistry.sol
@@ -394,17 +394,17 @@ contract PermissionedNodeRegistry is
      * @notice propose the new reward address of an operator
      * @dev only the existing reward address (msg.sender) can propose
      * @param _operatorAddress operator address
-     * @param _rewardAddress new reward address
+     * @param _newRewardAddress new reward address
      */
-    function initiateRewardAddressChange(address _operatorAddress, address _rewardAddress) external override {
-        UtilLib.checkNonZeroAddress(_rewardAddress);
+    function proposeRewardAddress(address _operatorAddress, address _newRewardAddress) external override {
+        UtilLib.checkNonZeroAddress(_newRewardAddress);
         uint256 _operatorId = operatorIDByAddress[_operatorAddress];
-        address operatorRewardAddress = operatorStructById[_operatorId].operatorRewardAddress;
-        if (msg.sender != operatorRewardAddress) {
+        address existingRewardAddress = operatorStructById[_operatorId].operatorRewardAddress;
+        if (msg.sender != existingRewardAddress) {
             revert CallerNotExistingRewardAddress();
         }
-        proposedRewardAddressByOperatorId[_operatorId] = _rewardAddress;
-        emit InitiatedRewardAddressChange(_operatorAddress, _rewardAddress);
+        proposedRewardAddressByOperatorId[_operatorId] = _newRewardAddress;
+        emit RewardAddressProposed(_operatorAddress, _newRewardAddress);
     }
 
     /**
@@ -420,7 +420,7 @@ contract PermissionedNodeRegistry is
         delete proposedRewardAddressByOperatorId[_operatorId];
 
         operatorStructById[_operatorId].operatorRewardAddress = payable(msg.sender);
-        emit UpdatedOperatorRewardAddress(_operatorAddress, msg.sender);
+        emit OperatorRewardAddressUpdated(_operatorAddress, msg.sender);
     }
 
     /**

--- a/contracts/PermissionedNodeRegistry.sol
+++ b/contracts/PermissionedNodeRegistry.sol
@@ -415,7 +415,7 @@ contract PermissionedNodeRegistry is
     function confirmRewardAddressChange(address _operatorAddress) external override {
         uint256 _operatorId = operatorIDByAddress[_operatorAddress];
         if (msg.sender != proposedRewardAddressByOperatorId[_operatorId]) {
-            revert OnlyNewRewardAddressCanConfirm();
+            revert CallerNotNewRewardAddress();
         }
         delete proposedRewardAddressByOperatorId[_operatorId];
 

--- a/contracts/PermissionedNodeRegistry.sol
+++ b/contracts/PermissionedNodeRegistry.sol
@@ -56,7 +56,7 @@ contract PermissionedNodeRegistry is
     //mapping of operator Id and nextQueuedValidatorIndex
     mapping(uint256 => uint256) public override nextQueuedValidatorIndexByOperatorId;
     mapping(uint256 => uint256) public socializingPoolStateChangeBlock;
-    mapping(uint256 => address) public pendingRewardAddressByOperatorId;
+    mapping(uint256 => address) public proposedRewardAddressByOperatorId;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -401,9 +401,9 @@ contract PermissionedNodeRegistry is
         uint256 _operatorId = operatorIDByAddress[_operatorAddress];
         address operatorRewardAddress = operatorStructById[_operatorId].operatorRewardAddress;
         if (msg.sender != operatorRewardAddress) {
-            revert OnlyExistingRewardAddressCanProposeNewRewardAddress();
+            revert CallerNotExistingRewardAddress();
         }
-        pendingRewardAddressByOperatorId[_operatorId] = _rewardAddress;
+        proposedRewardAddressByOperatorId[_operatorId] = _rewardAddress;
         emit InitiatedRewardAddressChange(_operatorAddress, _rewardAddress);
     }
 
@@ -414,10 +414,10 @@ contract PermissionedNodeRegistry is
      */
     function confirmRewardAddressChange(address _operatorAddress) external override {
         uint256 _operatorId = operatorIDByAddress[_operatorAddress];
-        if (msg.sender != pendingRewardAddressByOperatorId[_operatorId]) {
+        if (msg.sender != proposedRewardAddressByOperatorId[_operatorId]) {
             revert OnlyNewRewardAddressCanConfirm();
         }
-        delete pendingRewardAddressByOperatorId[_operatorId];
+        delete proposedRewardAddressByOperatorId[_operatorId];
 
         operatorStructById[_operatorId].operatorRewardAddress = payable(msg.sender);
         emit UpdatedOperatorRewardAddress(_operatorAddress, msg.sender);

--- a/contracts/PermissionedNodeRegistry.sol
+++ b/contracts/PermissionedNodeRegistry.sol
@@ -56,6 +56,7 @@ contract PermissionedNodeRegistry is
     //mapping of operator Id and nextQueuedValidatorIndex
     mapping(uint256 => uint256) public override nextQueuedValidatorIndexByOperatorId;
     mapping(uint256 => uint256) public socializingPoolStateChangeBlock;
+    mapping(uint256 => address) public pendingRewardAddressByOperatorId;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -390,19 +391,49 @@ contract PermissionedNodeRegistry is
     }
 
     /**
-     * @notice update the name and reward address of an operator
-     * @dev only operator msg.sender can update
-     * @param _operatorName new Name of the operator
+     * @notice propose the new reward address of an operator
+     * @dev only the existing reward address (msg.sender) can propose
+     * @param _operatorAddress operator address
      * @param _rewardAddress new reward address
      */
-    function updateOperatorDetails(string calldata _operatorName, address payable _rewardAddress) external override {
-        IPoolUtils(staderConfig.getPoolUtils()).onlyValidName(_operatorName);
+    function initiateRewardAddressChange(address _operatorAddress, address _rewardAddress) external override {
         UtilLib.checkNonZeroAddress(_rewardAddress);
+        uint256 _operatorId = operatorIDByAddress[_operatorAddress];
+        address operatorRewardAddress = operatorStructById[_operatorId].operatorRewardAddress;
+        if (msg.sender != operatorRewardAddress) {
+            revert OnlyExistingRewardAddressCanProposeNewRewardAddress();
+        }
+        pendingRewardAddressByOperatorId[_operatorId] = _rewardAddress;
+        emit InitiatedRewardAddressChange(_operatorAddress, _rewardAddress);
+    }
+
+    /**
+     * @notice confirms and sets the new reward address of an operator
+     * @dev only the new reward address (msg.sender) can confirm
+     * @param _operatorAddress operator address
+     */
+    function confirmRewardAddressChange(address _operatorAddress) external override {
+        uint256 _operatorId = operatorIDByAddress[_operatorAddress];
+        if (msg.sender != pendingRewardAddressByOperatorId[_operatorId]) {
+            revert OnlyNewRewardAddressCanConfirm();
+        }
+        delete pendingRewardAddressByOperatorId[_operatorId];
+
+        operatorStructById[_operatorId].operatorRewardAddress = payable(msg.sender);
+        emit UpdatedOperatorRewardAddress(_operatorAddress, msg.sender);
+    }
+
+    /**
+     * @notice update the name of an operator
+     * @dev only operator msg.sender can update
+     * @param _operatorName new Name of the operator
+     */
+    function updateOperatorName(string calldata _operatorName) external override {
+        IPoolUtils(staderConfig.getPoolUtils()).onlyValidName(_operatorName);
         onlyActiveOperator(msg.sender);
         uint256 operatorId = operatorIDByAddress[msg.sender];
         operatorStructById[operatorId].operatorName = _operatorName;
-        operatorStructById[operatorId].operatorRewardAddress = _rewardAddress;
-        emit UpdatedOperatorDetails(msg.sender, _operatorName, _rewardAddress);
+        emit UpdatedOperatorName(msg.sender, _operatorName);
     }
 
     /**

--- a/contracts/PermissionlessNodeRegistry.sol
+++ b/contracts/PermissionlessNodeRegistry.sol
@@ -383,7 +383,7 @@ contract PermissionlessNodeRegistry is
     function confirmRewardAddressChange(address _operatorAddress) external override {
         uint256 _operatorId = operatorIDByAddress[_operatorAddress];
         if (msg.sender != proposedRewardAddressByOperatorId[_operatorId]) {
-            revert OnlyNewRewardAddressCanConfirm();
+            revert CallerNotNewRewardAddress();
         }
         delete proposedRewardAddressByOperatorId[_operatorId];
 

--- a/contracts/PermissionlessNodeRegistry.sol
+++ b/contracts/PermissionlessNodeRegistry.sol
@@ -394,7 +394,7 @@ contract PermissionlessNodeRegistry is
     /**
      * @notice update the name of an operator
      * @dev only operator msg.sender can update
-     * @param _operatorName new Name of the operator
+     * @param _operatorName new name of the operator
      */
     function updateOperatorName(string calldata _operatorName) external override {
         IPoolUtils(staderConfig.getPoolUtils()).onlyValidName(_operatorName);

--- a/contracts/PermissionlessNodeRegistry.sol
+++ b/contracts/PermissionlessNodeRegistry.sol
@@ -57,7 +57,7 @@ contract PermissionlessNodeRegistry is
     mapping(uint256 => uint256) public socializingPoolStateChangeBlock;
     //mapping of operator address with nodeELReward vault address
     mapping(uint256 => address) public override nodeELRewardVaultByOperatorId;
-    mapping(uint256 => address) public pendingRewardAddressByOperatorId;
+    mapping(uint256 => address) public proposedRewardAddressByOperatorId;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -369,9 +369,9 @@ contract PermissionlessNodeRegistry is
         uint256 _operatorId = operatorIDByAddress[_operatorAddress];
         address operatorRewardAddress = operatorStructById[_operatorId].operatorRewardAddress;
         if (msg.sender != operatorRewardAddress) {
-            revert OnlyExistingRewardAddressCanProposeNewRewardAddress();
+            revert CallerNotExistingRewardAddress();
         }
-        pendingRewardAddressByOperatorId[_operatorId] = _rewardAddress;
+        proposedRewardAddressByOperatorId[_operatorId] = _rewardAddress;
         emit InitiatedRewardAddressChange(_operatorAddress, _rewardAddress);
     }
 
@@ -382,10 +382,10 @@ contract PermissionlessNodeRegistry is
      */
     function confirmRewardAddressChange(address _operatorAddress) external override {
         uint256 _operatorId = operatorIDByAddress[_operatorAddress];
-        if (msg.sender != pendingRewardAddressByOperatorId[_operatorId]) {
+        if (msg.sender != proposedRewardAddressByOperatorId[_operatorId]) {
             revert OnlyNewRewardAddressCanConfirm();
         }
-        delete pendingRewardAddressByOperatorId[_operatorId];
+        delete proposedRewardAddressByOperatorId[_operatorId];
 
         operatorStructById[_operatorId].operatorRewardAddress = payable(msg.sender);
         emit UpdatedOperatorRewardAddress(_operatorAddress, msg.sender);

--- a/contracts/PermissionlessNodeRegistry.sol
+++ b/contracts/PermissionlessNodeRegistry.sol
@@ -362,17 +362,17 @@ contract PermissionlessNodeRegistry is
      * @notice propose the new reward address of an operator
      * @dev only the existing reward address (msg.sender) can propose
      * @param _operatorAddress operator address
-     * @param _rewardAddress new reward address
+     * @param _newRewardAddress new reward address
      */
-    function initiateRewardAddressChange(address _operatorAddress, address _rewardAddress) external override {
-        UtilLib.checkNonZeroAddress(_rewardAddress);
+    function proposeRewardAddress(address _operatorAddress, address _newRewardAddress) external override {
+        UtilLib.checkNonZeroAddress(_newRewardAddress);
         uint256 _operatorId = operatorIDByAddress[_operatorAddress];
-        address operatorRewardAddress = operatorStructById[_operatorId].operatorRewardAddress;
-        if (msg.sender != operatorRewardAddress) {
+        address existingRewardAddress = operatorStructById[_operatorId].operatorRewardAddress;
+        if (msg.sender != existingRewardAddress) {
             revert CallerNotExistingRewardAddress();
         }
-        proposedRewardAddressByOperatorId[_operatorId] = _rewardAddress;
-        emit InitiatedRewardAddressChange(_operatorAddress, _rewardAddress);
+        proposedRewardAddressByOperatorId[_operatorId] = _newRewardAddress;
+        emit RewardAddressProposed(_operatorAddress, _newRewardAddress);
     }
 
     /**
@@ -388,7 +388,7 @@ contract PermissionlessNodeRegistry is
         delete proposedRewardAddressByOperatorId[_operatorId];
 
         operatorStructById[_operatorId].operatorRewardAddress = payable(msg.sender);
-        emit UpdatedOperatorRewardAddress(_operatorAddress, msg.sender);
+        emit OperatorRewardAddressUpdated(_operatorAddress, msg.sender);
     }
 
     /**

--- a/contracts/PermissionlessNodeRegistry.sol
+++ b/contracts/PermissionlessNodeRegistry.sol
@@ -57,6 +57,7 @@ contract PermissionlessNodeRegistry is
     mapping(uint256 => uint256) public socializingPoolStateChangeBlock;
     //mapping of operator address with nodeELReward vault address
     mapping(uint256 => address) public override nodeELRewardVaultByOperatorId;
+    mapping(uint256 => address) public pendingRewardAddressByOperatorId;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -358,19 +359,49 @@ contract PermissionlessNodeRegistry is
     }
 
     /**
-     * @notice update the name and reward address of an operator
-     * @dev only node operator can update
-     * @param _operatorName new name of the operator
+     * @notice propose the new reward address of an operator
+     * @dev only the existing reward address (msg.sender) can propose
+     * @param _operatorAddress operator address
      * @param _rewardAddress new reward address
      */
-    function updateOperatorDetails(string calldata _operatorName, address payable _rewardAddress) external override {
-        IPoolUtils(staderConfig.getPoolUtils()).onlyValidName(_operatorName);
+    function initiateRewardAddressChange(address _operatorAddress, address _rewardAddress) external override {
         UtilLib.checkNonZeroAddress(_rewardAddress);
+        uint256 _operatorId = operatorIDByAddress[_operatorAddress];
+        address operatorRewardAddress = operatorStructById[_operatorId].operatorRewardAddress;
+        if (msg.sender != operatorRewardAddress) {
+            revert OnlyExistingRewardAddressCanProposeNewRewardAddress();
+        }
+        pendingRewardAddressByOperatorId[_operatorId] = _rewardAddress;
+        emit InitiatedRewardAddressChange(_operatorAddress, _rewardAddress);
+    }
+
+    /**
+     * @notice confirms and sets the new reward address of an operator
+     * @dev only the new reward address (msg.sender) can confirm
+     * @param _operatorAddress operator address
+     */
+    function confirmRewardAddressChange(address _operatorAddress) external override {
+        uint256 _operatorId = operatorIDByAddress[_operatorAddress];
+        if (msg.sender != pendingRewardAddressByOperatorId[_operatorId]) {
+            revert OnlyNewRewardAddressCanConfirm();
+        }
+        delete pendingRewardAddressByOperatorId[_operatorId];
+
+        operatorStructById[_operatorId].operatorRewardAddress = payable(msg.sender);
+        emit UpdatedOperatorRewardAddress(_operatorAddress, msg.sender);
+    }
+
+    /**
+     * @notice update the name of an operator
+     * @dev only operator msg.sender can update
+     * @param _operatorName new Name of the operator
+     */
+    function updateOperatorName(string calldata _operatorName) external override {
+        IPoolUtils(staderConfig.getPoolUtils()).onlyValidName(_operatorName);
         onlyActiveOperator(msg.sender);
         uint256 operatorId = operatorIDByAddress[msg.sender];
         operatorStructById[operatorId].operatorName = _operatorName;
-        operatorStructById[operatorId].operatorRewardAddress = _rewardAddress;
-        emit UpdatedOperatorDetails(msg.sender, _operatorName, _rewardAddress);
+        emit UpdatedOperatorName(msg.sender, _operatorName);
     }
 
     /**

--- a/contracts/interfaces/INodeRegistry.sol
+++ b/contracts/interfaces/INodeRegistry.sol
@@ -51,8 +51,8 @@ interface INodeRegistry {
     event UpdatedMaxNonTerminalKeyPerOperator(uint64 maxNonTerminalKeyPerOperator);
     event UpdatedInputKeyCountLimit(uint256 batchKeyDepositLimit);
     event UpdatedStaderConfig(address staderConfig);
-    event InitiatedRewardAddressChange(address indexed nodeOperator, address indexed rewardAddress);
-    event UpdatedOperatorRewardAddress(address indexed nodeOperator, address indexed rewardAddress);
+    event RewardAddressProposed(address indexed nodeOperator, address indexed rewardAddress);
+    event OperatorRewardAddressUpdated(address indexed nodeOperator, address indexed rewardAddress);
     event UpdatedOperatorName(address indexed nodeOperator, string operatorName);
     event IncreasedTotalActiveValidatorCount(uint256 totalActiveValidatorCount);
     event UpdatedVerifiedKeyBatchSize(uint256 verifiedKeysBatchSize);

--- a/contracts/interfaces/INodeRegistry.sol
+++ b/contracts/interfaces/INodeRegistry.sol
@@ -39,6 +39,8 @@ interface INodeRegistry {
     error NotEnoughSDCollateral();
     error TooManyVerifiedKeysReported();
     error TooManyWithdrawnKeysReported();
+    error OnlyExistingRewardAddressCanProposeNewRewardAddress();
+    error OnlyNewRewardAddressCanConfirm();
 
     // Events
     event AddedValidatorKey(address indexed nodeOperator, bytes pubkey, uint256 validatorId);
@@ -49,7 +51,9 @@ interface INodeRegistry {
     event UpdatedMaxNonTerminalKeyPerOperator(uint64 maxNonTerminalKeyPerOperator);
     event UpdatedInputKeyCountLimit(uint256 batchKeyDepositLimit);
     event UpdatedStaderConfig(address staderConfig);
-    event UpdatedOperatorDetails(address indexed nodeOperator, string operatorName, address rewardAddress);
+    event InitiatedRewardAddressChange(address indexed nodeOperator, address indexed rewardAddress);
+    event UpdatedOperatorRewardAddress(address indexed nodeOperator, address indexed rewardAddress);
+    event UpdatedOperatorName(address indexed nodeOperator, string operatorName);
     event IncreasedTotalActiveValidatorCount(uint256 totalActiveValidatorCount);
     event UpdatedVerifiedKeyBatchSize(uint256 verifiedKeysBatchSize);
     event UpdatedWithdrawnKeyBatchSize(uint256 withdrawnKeysBatchSize);

--- a/contracts/interfaces/INodeRegistry.sol
+++ b/contracts/interfaces/INodeRegistry.sol
@@ -40,7 +40,7 @@ interface INodeRegistry {
     error TooManyVerifiedKeysReported();
     error TooManyWithdrawnKeysReported();
     error CallerNotExistingRewardAddress();
-    error OnlyNewRewardAddressCanConfirm();
+    error CallerNotNewRewardAddress();
 
     // Events
     event AddedValidatorKey(address indexed nodeOperator, bytes pubkey, uint256 validatorId);

--- a/contracts/interfaces/INodeRegistry.sol
+++ b/contracts/interfaces/INodeRegistry.sol
@@ -39,7 +39,7 @@ interface INodeRegistry {
     error NotEnoughSDCollateral();
     error TooManyVerifiedKeysReported();
     error TooManyWithdrawnKeysReported();
-    error OnlyExistingRewardAddressCanProposeNewRewardAddress();
+    error CallerNotExistingRewardAddress();
     error OnlyNewRewardAddressCanConfirm();
 
     // Events

--- a/contracts/interfaces/IPermissionedNodeRegistry.sol
+++ b/contracts/interfaces/IPermissionedNodeRegistry.sol
@@ -68,7 +68,7 @@ interface IPermissionedNodeRegistry {
 
     function updateInputKeyCountLimit(uint16 _inputKeyCountLimit) external;
 
-    function initiateRewardAddressChange(address _operatorAddress, address _rewardAddress) external;
+    function proposeRewardAddress(address _operatorAddress, address _newRewardAddress) external;
 
     function confirmRewardAddressChange(address _operatorAddress) external;
 

--- a/contracts/interfaces/IPermissionedNodeRegistry.sol
+++ b/contracts/interfaces/IPermissionedNodeRegistry.sol
@@ -68,7 +68,11 @@ interface IPermissionedNodeRegistry {
 
     function updateInputKeyCountLimit(uint16 _inputKeyCountLimit) external;
 
-    function updateOperatorDetails(string calldata _operatorName, address payable _rewardAddress) external;
+    function initiateRewardAddressChange(address _operatorAddress, address _rewardAddress) external;
+
+    function confirmRewardAddressChange(address _operatorAddress) external;
+
+    function updateOperatorName(string calldata _operatorName) external;
 
     function pause() external;
 

--- a/contracts/interfaces/IPermissionlessNodeRegistry.sol
+++ b/contracts/interfaces/IPermissionlessNodeRegistry.sol
@@ -64,7 +64,11 @@ interface IPermissionlessNodeRegistry {
 
     function updateMaxNonTerminalKeyPerOperator(uint64 _maxNonTerminalKeyPerOperator) external;
 
-    function updateOperatorDetails(string calldata _operatorName, address payable _rewardAddress) external;
+    function initiateRewardAddressChange(address _operatorAddress, address _rewardAddress) external;
+
+    function confirmRewardAddressChange(address _operatorAddress) external;
+
+    function updateOperatorName(string calldata _operatorName) external;
 
     function changeSocializingPoolState(bool _optInForSocializingPool)
         external

--- a/contracts/interfaces/IPermissionlessNodeRegistry.sol
+++ b/contracts/interfaces/IPermissionlessNodeRegistry.sol
@@ -64,7 +64,7 @@ interface IPermissionlessNodeRegistry {
 
     function updateMaxNonTerminalKeyPerOperator(uint64 _maxNonTerminalKeyPerOperator) external;
 
-    function initiateRewardAddressChange(address _operatorAddress, address _rewardAddress) external;
+    function proposeRewardAddress(address _operatorAddress, address _newRewardAddress) external;
 
     function confirmRewardAddressChange(address _operatorAddress) external;
 

--- a/test/foundry_tests/PermissionedNodeRegistry.t.sol
+++ b/test/foundry_tests/PermissionedNodeRegistry.t.sol
@@ -469,14 +469,14 @@ contract PermissionedNodeRegistryTest is Test {
         string memory newOpName = string(abi.encodePacked(_operatorName, 'test'));
 
         // propose new reward addr
-        vm.expectRevert(INodeRegistry.OnlyExistingRewardAddressCanProposeNewRewardAddress.selector);
+        vm.expectRevert(INodeRegistry.CallerNotExistingRewardAddress.selector);
         vm.prank(operatorAddr);
         nodeRegistry.initiateRewardAddressChange(operatorAddr, newOPRewardAddr);
 
         vm.prank(opRewardAddr);
         nodeRegistry.initiateRewardAddressChange(operatorAddr, newOPRewardAddr);
 
-        address pendingRewardAddress = nodeRegistry.pendingRewardAddressByOperatorId(operatorId);
+        address pendingRewardAddress = nodeRegistry.proposedRewardAddressByOperatorId(operatorId);
         assertEq(pendingRewardAddress, newOPRewardAddr);
 
         // confirm new reward address
@@ -495,7 +495,9 @@ contract PermissionedNodeRegistryTest is Test {
         assertEq(operatorRewardAddress, newOPRewardAddr);
     }
 
-    function test_updateOperatorDetailWithZeroRewardAddr(string calldata _operatorName, uint64 __opAddrSeed) public {
+    function test_updateOperatorRewardAddressWithZeroRewardAddr(string calldata _operatorName, uint64 __opAddrSeed)
+        public
+    {
         vm.assume(bytes(_operatorName).length > 0 && bytes(_operatorName).length < 255);
         vm.assume(__opAddrSeed > 0);
         address operatorAddr = vm.addr(__opAddrSeed);

--- a/test/foundry_tests/PermissionedNodeRegistry.t.sol
+++ b/test/foundry_tests/PermissionedNodeRegistry.t.sol
@@ -480,11 +480,11 @@ contract PermissionedNodeRegistryTest is Test {
         assertEq(pendingRewardAddress, newOPRewardAddr);
 
         // confirm new reward address
-        vm.expectRevert(INodeRegistry.OnlyNewRewardAddressCanConfirm.selector);
+        vm.expectRevert(INodeRegistry.CallerNotNewRewardAddress.selector);
         vm.prank(opRewardAddr);
         nodeRegistry.confirmRewardAddressChange(operatorAddr);
 
-        vm.expectRevert(INodeRegistry.OnlyNewRewardAddressCanConfirm.selector);
+        vm.expectRevert(INodeRegistry.CallerNotNewRewardAddress.selector);
         vm.prank(operatorAddr);
         nodeRegistry.confirmRewardAddressChange(operatorAddr);
 

--- a/test/foundry_tests/PermissionedNodeRegistry.t.sol
+++ b/test/foundry_tests/PermissionedNodeRegistry.t.sol
@@ -471,14 +471,14 @@ contract PermissionedNodeRegistryTest is Test {
         // propose new reward addr
         vm.expectRevert(INodeRegistry.CallerNotExistingRewardAddress.selector);
         vm.prank(operatorAddr);
-        nodeRegistry.initiateRewardAddressChange(operatorAddr, newOPRewardAddr);
+        nodeRegistry.proposeRewardAddress(operatorAddr, newOPRewardAddr);
 
         // passed wrong new reward address by mistake
         vm.prank(opRewardAddr);
-        nodeRegistry.initiateRewardAddressChange(operatorAddr, vm.addr(666));
+        nodeRegistry.proposeRewardAddress(operatorAddr, vm.addr(666));
 
         vm.prank(opRewardAddr);
-        nodeRegistry.initiateRewardAddressChange(operatorAddr, newOPRewardAddr);
+        nodeRegistry.proposeRewardAddress(operatorAddr, newOPRewardAddr);
 
         address pendingRewardAddress = nodeRegistry.proposedRewardAddressByOperatorId(operatorId);
         assertEq(pendingRewardAddress, newOPRewardAddr);
@@ -506,11 +506,11 @@ contract PermissionedNodeRegistryTest is Test {
 
         vm.expectRevert(INodeRegistry.CallerNotExistingRewardAddress.selector);
         vm.prank(opRewardAddr);
-        nodeRegistry.initiateRewardAddressChange(operatorAddr, newOPRewardAddr);
+        nodeRegistry.proposeRewardAddress(operatorAddr, newOPRewardAddr);
 
         // it will pass if caller is address(0), which is not possible
         vm.prank(address(0));
-        nodeRegistry.initiateRewardAddressChange(operatorAddr, newOPRewardAddr);
+        nodeRegistry.proposeRewardAddress(operatorAddr, newOPRewardAddr);
     }
 
     function test_updateOperatorRewardAddressWithZeroRewardAddr(string calldata _operatorName, uint64 __opAddrSeed)
@@ -525,7 +525,7 @@ contract PermissionedNodeRegistryTest is Test {
 
         vm.expectRevert(UtilLib.ZeroAddress.selector);
         vm.prank(operatorAddr);
-        nodeRegistry.initiateRewardAddressChange(operatorAddr, payable(address(0)));
+        nodeRegistry.proposeRewardAddress(operatorAddr, payable(address(0)));
     }
 
     function test_updateOperatorName(string calldata _operatorName, uint64 __opAddrSeed) public {

--- a/test/foundry_tests/PermissionedNodeRegistry.t.sol
+++ b/test/foundry_tests/PermissionedNodeRegistry.t.sol
@@ -495,6 +495,20 @@ contract PermissionedNodeRegistryTest is Test {
         assertEq(operatorRewardAddress, newOPRewardAddr);
     }
 
+    function test_updateOperatorRewardAddressWithInvalidOperatorAddress() public {
+        address operatorAddr = vm.addr(778);
+        address payable opRewardAddr = payable(vm.addr(456));
+        address payable newOPRewardAddr = payable(vm.addr(567));
+
+        vm.expectRevert(INodeRegistry.CallerNotExistingRewardAddress.selector);
+        vm.prank(opRewardAddr);
+        nodeRegistry.initiateRewardAddressChange(operatorAddr, newOPRewardAddr);
+
+        // it will pass if caller is address(0), which is not possible
+        vm.prank(address(0));
+        nodeRegistry.initiateRewardAddressChange(operatorAddr, newOPRewardAddr);
+    }
+
     function test_updateOperatorRewardAddressWithZeroRewardAddr(string calldata _operatorName, uint64 __opAddrSeed)
         public
     {

--- a/test/foundry_tests/PermissionedNodeRegistry.t.sol
+++ b/test/foundry_tests/PermissionedNodeRegistry.t.sol
@@ -454,42 +454,45 @@ contract PermissionedNodeRegistryTest is Test {
         assertEq(address(nodeRegistry.staderConfig()), newStaderConfig);
     }
 
-    function test_updateOperatorDetails(
-        string calldata _operatorName,
-        uint64 __opAddrSeed,
-        uint64 _opRewardAddrSeed,
-        uint64 _newOPRewardAddrSeed
-    ) public {
+    function test_updateOperatorRewardAddress(string calldata _operatorName, uint64 __opAddrSeed) public {
         vm.assume(bytes(_operatorName).length > 0 && bytes(_operatorName).length < 255);
         vm.assume(__opAddrSeed > 0);
-        vm.assume(_opRewardAddrSeed > 0);
-        vm.assume(_newOPRewardAddrSeed > 0);
         address operatorAddr = vm.addr(__opAddrSeed);
-        address payable opRewardAddr = payable(vm.addr(_opRewardAddrSeed));
-        address payable newOPRewardAddr = payable(vm.addr(_newOPRewardAddrSeed));
+        address payable opRewardAddr = payable(vm.addr(456));
+        address payable newOPRewardAddr = payable(vm.addr(567));
         whitelistOperator(operatorAddr);
-        vm.startPrank(operatorAddr);
+
+        vm.prank(operatorAddr);
         nodeRegistry.onboardNodeOperator(_operatorName, opRewardAddr);
+
         uint256 operatorId = nodeRegistry.operatorIDByAddress(operatorAddr);
         string memory newOpName = string(abi.encodePacked(_operatorName, 'test'));
-        nodeRegistry.updateOperatorDetails(newOpName, newOPRewardAddr);
-        (, , string memory operatorName, address payable operatorRewardAddress, ) = nodeRegistry.operatorStructById(
-            operatorId
-        );
-        assertEq(operatorName, newOpName);
-        assertEq(operatorRewardAddress, newOPRewardAddr);
-        vm.stopPrank();
-    }
 
-    function test_updateOperatorDetailWithInActiveOperator(string calldata _operatorName, uint64 _opRewardAddrSeed)
-        public
-    {
-        vm.assume(bytes(_operatorName).length > 0 && bytes(_operatorName).length < 255);
-        vm.assume(_opRewardAddrSeed > 0);
-        address payable opRewardAddr = payable(vm.addr(_opRewardAddrSeed));
-        string memory newOpName = string(abi.encodePacked(_operatorName, 'test'));
-        vm.expectRevert(INodeRegistry.OperatorNotOnBoarded.selector);
-        nodeRegistry.updateOperatorDetails(newOpName, payable(opRewardAddr));
+        // propose new reward addr
+        vm.expectRevert(INodeRegistry.OnlyExistingRewardAddressCanProposeNewRewardAddress.selector);
+        vm.prank(operatorAddr);
+        nodeRegistry.initiateRewardAddressChange(operatorAddr, newOPRewardAddr);
+
+        vm.prank(opRewardAddr);
+        nodeRegistry.initiateRewardAddressChange(operatorAddr, newOPRewardAddr);
+
+        address pendingRewardAddress = nodeRegistry.pendingRewardAddressByOperatorId(operatorId);
+        assertEq(pendingRewardAddress, newOPRewardAddr);
+
+        // confirm new reward address
+        vm.expectRevert(INodeRegistry.OnlyNewRewardAddressCanConfirm.selector);
+        vm.prank(opRewardAddr);
+        nodeRegistry.confirmRewardAddressChange(operatorAddr);
+
+        vm.expectRevert(INodeRegistry.OnlyNewRewardAddressCanConfirm.selector);
+        vm.prank(operatorAddr);
+        nodeRegistry.confirmRewardAddressChange(operatorAddr);
+
+        vm.prank(newOPRewardAddr);
+        nodeRegistry.confirmRewardAddressChange(operatorAddr);
+
+        (, , , address payable operatorRewardAddress, ) = nodeRegistry.operatorStructById(operatorId);
+        assertEq(operatorRewardAddress, newOPRewardAddr);
     }
 
     function test_updateOperatorDetailWithZeroRewardAddr(string calldata _operatorName, uint64 __opAddrSeed) public {
@@ -497,33 +500,46 @@ contract PermissionedNodeRegistryTest is Test {
         vm.assume(__opAddrSeed > 0);
         address operatorAddr = vm.addr(__opAddrSeed);
         whitelistOperator(operatorAddr);
+        vm.prank(operatorAddr);
+        nodeRegistry.onboardNodeOperator(_operatorName, payable(operatorAddr));
+
+        vm.expectRevert(UtilLib.ZeroAddress.selector);
+        vm.prank(operatorAddr);
+        nodeRegistry.initiateRewardAddressChange(operatorAddr, payable(address(0)));
+    }
+
+    function test_updateOperatorName(string calldata _operatorName, uint64 __opAddrSeed) public {
+        vm.assume(bytes(_operatorName).length > 0 && bytes(_operatorName).length < 255);
+        vm.assume(__opAddrSeed > 0);
+        address operatorAddr = vm.addr(__opAddrSeed);
+        whitelistOperator(operatorAddr);
         vm.startPrank(operatorAddr);
         nodeRegistry.onboardNodeOperator(_operatorName, payable(operatorAddr));
+        uint256 operatorId = nodeRegistry.operatorIDByAddress(operatorAddr);
         string memory newOpName = string(abi.encodePacked(_operatorName, 'test'));
-        vm.expectRevert(UtilLib.ZeroAddress.selector);
-        nodeRegistry.updateOperatorDetails(newOpName, payable(address(0)));
+        nodeRegistry.updateOperatorName(newOpName);
+        (, , string memory operatorName, , ) = nodeRegistry.operatorStructById(operatorId);
+        assertEq(operatorName, newOpName);
         vm.stopPrank();
     }
 
-    function test_updateOperatorDetailWithInvalidName(
-        string calldata _operatorName,
-        uint64 __opAddrSeed,
-        uint64 _opRewardAddrSeed,
-        uint64 _newOPRewardAddrSeed
-    ) public {
+    function test_updateOperatorNameWithInActiveOperator(string calldata _operatorName) public {
+        vm.assume(bytes(_operatorName).length > 0 && bytes(_operatorName).length < 255);
+        string memory newOpName = string(abi.encodePacked(_operatorName, 'test'));
+        vm.expectRevert(INodeRegistry.OperatorNotOnBoarded.selector);
+        nodeRegistry.updateOperatorName(newOpName);
+    }
+
+    function test_updateOperatorNameWithInvalidName(string calldata _operatorName, uint64 __opAddrSeed) public {
         vm.assume(bytes(_operatorName).length > 0 && bytes(_operatorName).length < 255);
         vm.assume(__opAddrSeed > 0);
-        vm.assume(_opRewardAddrSeed > 0);
-        vm.assume(_newOPRewardAddrSeed > 0);
         address operatorAddr = vm.addr(__opAddrSeed);
-        address payable opRewardAddr = payable(vm.addr(_opRewardAddrSeed));
-        address payable newOPRewardAddr = payable(vm.addr(_newOPRewardAddrSeed));
         whitelistOperator(operatorAddr);
         vm.startPrank(operatorAddr);
-        nodeRegistry.onboardNodeOperator(_operatorName, opRewardAddr);
+        nodeRegistry.onboardNodeOperator(_operatorName, payable(operatorAddr));
         string memory newOpName = string(abi.encodePacked(''));
         vm.expectRevert(PoolUtilsMockForDepositFlow.EmptyNameString.selector);
-        nodeRegistry.updateOperatorDetails(newOpName, newOPRewardAddr);
+        nodeRegistry.updateOperatorName(newOpName);
     }
 
     function test_increaseTotalActiveValidatorCount(uint256 _count) public {

--- a/test/foundry_tests/PermissionedNodeRegistry.t.sol
+++ b/test/foundry_tests/PermissionedNodeRegistry.t.sol
@@ -473,6 +473,10 @@ contract PermissionedNodeRegistryTest is Test {
         vm.prank(operatorAddr);
         nodeRegistry.initiateRewardAddressChange(operatorAddr, newOPRewardAddr);
 
+        // passed wrong new reward address by mistake
+        vm.prank(opRewardAddr);
+        nodeRegistry.initiateRewardAddressChange(operatorAddr, vm.addr(666));
+
         vm.prank(opRewardAddr);
         nodeRegistry.initiateRewardAddressChange(operatorAddr, newOPRewardAddr);
 

--- a/test/foundry_tests/PermissionlessNodeRegistry.t.sol
+++ b/test/foundry_tests/PermissionlessNodeRegistry.t.sol
@@ -539,14 +539,14 @@ contract PermissionlessNodeRegistryTest is Test {
         // propose new reward addr
         vm.expectRevert(INodeRegistry.CallerNotExistingRewardAddress.selector);
         vm.prank(operatorAddr);
-        nodeRegistry.initiateRewardAddressChange(operatorAddr, newOPRewardAddr);
+        nodeRegistry.proposeRewardAddress(operatorAddr, newOPRewardAddr);
 
         // passed wrong new reward address by mistake
         vm.prank(opRewardAddr);
-        nodeRegistry.initiateRewardAddressChange(operatorAddr, vm.addr(666));
+        nodeRegistry.proposeRewardAddress(operatorAddr, vm.addr(666));
 
         vm.prank(opRewardAddr);
-        nodeRegistry.initiateRewardAddressChange(operatorAddr, newOPRewardAddr);
+        nodeRegistry.proposeRewardAddress(operatorAddr, newOPRewardAddr);
 
         address pendingRewardAddress = nodeRegistry.proposedRewardAddressByOperatorId(operatorId);
         assertEq(pendingRewardAddress, newOPRewardAddr);
@@ -574,11 +574,11 @@ contract PermissionlessNodeRegistryTest is Test {
 
         vm.expectRevert(INodeRegistry.CallerNotExistingRewardAddress.selector);
         vm.prank(opRewardAddr);
-        nodeRegistry.initiateRewardAddressChange(operatorAddr, newOPRewardAddr);
+        nodeRegistry.proposeRewardAddress(operatorAddr, newOPRewardAddr);
 
         // it will pass if caller is address(0), which is not possible
         vm.prank(address(0));
-        nodeRegistry.initiateRewardAddressChange(operatorAddr, newOPRewardAddr);
+        nodeRegistry.proposeRewardAddress(operatorAddr, newOPRewardAddr);
     }
 
     function test_updateOperatorRewardAddressWithZeroRewardAddr(string calldata _operatorName, uint64 __opAddrSeed)
@@ -592,7 +592,7 @@ contract PermissionlessNodeRegistryTest is Test {
 
         vm.expectRevert(UtilLib.ZeroAddress.selector);
         vm.prank(operatorAddr);
-        nodeRegistry.initiateRewardAddressChange(operatorAddr, payable(address(0)));
+        nodeRegistry.proposeRewardAddress(operatorAddr, payable(address(0)));
     }
 
     function test_updateOperatorName(string calldata _operatorName, uint64 __opAddrSeed) public {

--- a/test/foundry_tests/PermissionlessNodeRegistry.t.sol
+++ b/test/foundry_tests/PermissionlessNodeRegistry.t.sol
@@ -524,85 +524,88 @@ contract PermissionlessNodeRegistryTest is Test {
         assertEq(address(nodeRegistry.staderConfig()), newStaderConfig);
     }
 
-    function test_updateOperatorDetails(
-        string calldata _operatorName,
-        uint64 __opAddrSeed,
-        uint64 _opRewardAddrSeed,
-        uint64 _newOPRewardAddrSeed
-    ) public {
+    function test_updateOperatorRewardAddress(string calldata _operatorName, uint64 __opAddrSeed) public {
         vm.assume(bytes(_operatorName).length > 0 && bytes(_operatorName).length < 255);
         vm.assume(__opAddrSeed > 0);
-        vm.assume(_opRewardAddrSeed > 0);
-        vm.assume(_newOPRewardAddrSeed > 0);
         address operatorAddr = vm.addr(__opAddrSeed);
-        address payable opRewardAddr = payable(vm.addr(_opRewardAddrSeed));
-        address payable newOPRewardAddr = payable(vm.addr(_newOPRewardAddrSeed));
-        vm.startPrank(operatorAddr);
+        address payable opRewardAddr = payable(vm.addr(456));
+        address payable newOPRewardAddr = payable(vm.addr(567));
+
+        vm.prank(operatorAddr);
         nodeRegistry.onboardNodeOperator(false, _operatorName, opRewardAddr);
+
         uint256 operatorId = nodeRegistry.operatorIDByAddress(operatorAddr);
         string memory newOpName = string(abi.encodePacked(_operatorName, 'test'));
-        nodeRegistry.updateOperatorDetails(newOpName, newOPRewardAddr);
-        (, , string memory operatorName, address payable operatorRewardAddress, ) = nodeRegistry.operatorStructById(
-            operatorId
-        );
-        assertEq(operatorName, newOpName);
+
+        // propose new reward addr
+        vm.expectRevert(INodeRegistry.OnlyExistingRewardAddressCanProposeNewRewardAddress.selector);
+        vm.prank(operatorAddr);
+        nodeRegistry.initiateRewardAddressChange(operatorAddr, newOPRewardAddr);
+
+        vm.prank(opRewardAddr);
+        nodeRegistry.initiateRewardAddressChange(operatorAddr, newOPRewardAddr);
+
+        address pendingRewardAddress = nodeRegistry.pendingRewardAddressByOperatorId(operatorId);
+        assertEq(pendingRewardAddress, newOPRewardAddr);
+
+        // confirm new reward address
+        vm.expectRevert(INodeRegistry.OnlyNewRewardAddressCanConfirm.selector);
+        vm.prank(opRewardAddr);
+        nodeRegistry.confirmRewardAddressChange(operatorAddr);
+
+        vm.expectRevert(INodeRegistry.OnlyNewRewardAddressCanConfirm.selector);
+        vm.prank(operatorAddr);
+        nodeRegistry.confirmRewardAddressChange(operatorAddr);
+
+        vm.prank(newOPRewardAddr);
+        nodeRegistry.confirmRewardAddressChange(operatorAddr);
+
+        (, , , address payable operatorRewardAddress, ) = nodeRegistry.operatorStructById(operatorId);
         assertEq(operatorRewardAddress, newOPRewardAddr);
     }
 
-    function test_updateOperatorDetailWithInActiveOperator(
-        string calldata _operatorName,
-        uint64 __opAddrSeed,
-        uint64 _opRewardAddrSeed
-    ) public {
+    function test_updateOperatorDetailWithZeroRewardAddr(string calldata _operatorName, uint64 __opAddrSeed) public {
         vm.assume(bytes(_operatorName).length > 0 && bytes(_operatorName).length < 255);
         vm.assume(__opAddrSeed > 0);
-        vm.assume(_opRewardAddrSeed > 0);
         address operatorAddr = vm.addr(__opAddrSeed);
-        address payable opRewardAddr = payable(vm.addr(_opRewardAddrSeed));
         vm.prank(operatorAddr);
-        nodeRegistry.onboardNodeOperator(false, _operatorName, opRewardAddr);
+        nodeRegistry.onboardNodeOperator(false, _operatorName, payable(operatorAddr));
+
+        vm.expectRevert(UtilLib.ZeroAddress.selector);
+        vm.prank(operatorAddr);
+        nodeRegistry.initiateRewardAddressChange(operatorAddr, payable(address(0)));
+    }
+
+    function test_updateOperatorName(string calldata _operatorName, uint64 __opAddrSeed) public {
+        vm.assume(bytes(_operatorName).length > 0 && bytes(_operatorName).length < 255);
+        vm.assume(__opAddrSeed > 0);
+        address operatorAddr = vm.addr(__opAddrSeed);
+        vm.startPrank(operatorAddr);
+        nodeRegistry.onboardNodeOperator(false, _operatorName, payable(operatorAddr));
+        uint256 operatorId = nodeRegistry.operatorIDByAddress(operatorAddr);
+        string memory newOpName = string(abi.encodePacked(_operatorName, 'test'));
+        nodeRegistry.updateOperatorName(newOpName);
+        (, , string memory operatorName, , ) = nodeRegistry.operatorStructById(operatorId);
+        assertEq(operatorName, newOpName);
+        vm.stopPrank();
+    }
+
+    function test_updateOperatorNameWithInActiveOperator(string calldata _operatorName) public {
+        vm.assume(bytes(_operatorName).length > 0 && bytes(_operatorName).length < 255);
         string memory newOpName = string(abi.encodePacked(_operatorName, 'test'));
         vm.expectRevert(INodeRegistry.OperatorNotOnBoarded.selector);
-        nodeRegistry.updateOperatorDetails(newOpName, payable(operatorAddr));
+        nodeRegistry.updateOperatorName(newOpName);
     }
 
-    function test_updateOperatorDetailWithZeroRewardAddr(
-        string calldata _operatorName,
-        uint64 __opAddrSeed,
-        uint64 _opRewardAddrSeed
-    ) public {
+    function test_updateOperatorNameWithInvalidName(string calldata _operatorName, uint64 __opAddrSeed) public {
         vm.assume(bytes(_operatorName).length > 0 && bytes(_operatorName).length < 255);
         vm.assume(__opAddrSeed > 0);
-        vm.assume(_opRewardAddrSeed > 0);
         address operatorAddr = vm.addr(__opAddrSeed);
-        address payable opRewardAddr = payable(vm.addr(_opRewardAddrSeed));
         vm.startPrank(operatorAddr);
-        nodeRegistry.onboardNodeOperator(false, _operatorName, opRewardAddr);
-        string memory newOpName = string(abi.encodePacked(_operatorName, 'test'));
-        vm.expectRevert(UtilLib.ZeroAddress.selector);
-        nodeRegistry.updateOperatorDetails(newOpName, payable(address(0)));
-        vm.stopPrank();
-    }
-
-    function test_updateOperatorDetailWithInvalidName(
-        string calldata _operatorName,
-        uint64 __opAddrSeed,
-        uint64 _opRewardAddrSeed,
-        uint64 _newOPRewardAddrSeed
-    ) public {
-        vm.assume(bytes(_operatorName).length > 0 && bytes(_operatorName).length < 255);
-        vm.assume(__opAddrSeed > 0);
-        vm.assume(_opRewardAddrSeed > 0);
-        vm.assume(_newOPRewardAddrSeed > 0);
-        address operatorAddr = vm.addr(__opAddrSeed);
-        address payable opRewardAddr = payable(vm.addr(_opRewardAddrSeed));
-        address payable newOPRewardAddr = payable(vm.addr(_newOPRewardAddrSeed));
-        vm.startPrank(operatorAddr);
-        nodeRegistry.onboardNodeOperator(false, _operatorName, opRewardAddr);
+        nodeRegistry.onboardNodeOperator(false, _operatorName, payable(operatorAddr));
         string memory newOpName = string(abi.encodePacked(''));
         vm.expectRevert(PoolUtilsMockForDepositFlow.EmptyNameString.selector);
-        nodeRegistry.updateOperatorDetails(newOpName, newOPRewardAddr);
-        vm.stopPrank();
+        nodeRegistry.updateOperatorName(newOpName);
     }
 
     function test_increaseTotalActiveValidatorCount(uint256 _count) public {

--- a/test/foundry_tests/PermissionlessNodeRegistry.t.sol
+++ b/test/foundry_tests/PermissionlessNodeRegistry.t.sol
@@ -548,11 +548,11 @@ contract PermissionlessNodeRegistryTest is Test {
         assertEq(pendingRewardAddress, newOPRewardAddr);
 
         // confirm new reward address
-        vm.expectRevert(INodeRegistry.OnlyNewRewardAddressCanConfirm.selector);
+        vm.expectRevert(INodeRegistry.CallerNotNewRewardAddress.selector);
         vm.prank(opRewardAddr);
         nodeRegistry.confirmRewardAddressChange(operatorAddr);
 
-        vm.expectRevert(INodeRegistry.OnlyNewRewardAddressCanConfirm.selector);
+        vm.expectRevert(INodeRegistry.CallerNotNewRewardAddress.selector);
         vm.prank(operatorAddr);
         nodeRegistry.confirmRewardAddressChange(operatorAddr);
 

--- a/test/foundry_tests/PermissionlessNodeRegistry.t.sol
+++ b/test/foundry_tests/PermissionlessNodeRegistry.t.sol
@@ -541,6 +541,10 @@ contract PermissionlessNodeRegistryTest is Test {
         vm.prank(operatorAddr);
         nodeRegistry.initiateRewardAddressChange(operatorAddr, newOPRewardAddr);
 
+        // passed wrong new reward address by mistake
+        vm.prank(opRewardAddr);
+        nodeRegistry.initiateRewardAddressChange(operatorAddr, vm.addr(666));
+
         vm.prank(opRewardAddr);
         nodeRegistry.initiateRewardAddressChange(operatorAddr, newOPRewardAddr);
 

--- a/test/foundry_tests/PermissionlessNodeRegistry.t.sol
+++ b/test/foundry_tests/PermissionlessNodeRegistry.t.sol
@@ -535,7 +535,6 @@ contract PermissionlessNodeRegistryTest is Test {
         nodeRegistry.onboardNodeOperator(false, _operatorName, opRewardAddr);
 
         uint256 operatorId = nodeRegistry.operatorIDByAddress(operatorAddr);
-        string memory newOpName = string(abi.encodePacked(_operatorName, 'test'));
 
         // propose new reward addr
         vm.expectRevert(INodeRegistry.CallerNotExistingRewardAddress.selector);
@@ -562,6 +561,20 @@ contract PermissionlessNodeRegistryTest is Test {
 
         (, , , address payable operatorRewardAddress, ) = nodeRegistry.operatorStructById(operatorId);
         assertEq(operatorRewardAddress, newOPRewardAddr);
+    }
+
+    function test_updateOperatorRewardAddressWithInvalidOperatorAddress() public {
+        address operatorAddr = vm.addr(778);
+        address payable opRewardAddr = payable(vm.addr(456));
+        address payable newOPRewardAddr = payable(vm.addr(567));
+
+        vm.expectRevert(INodeRegistry.CallerNotExistingRewardAddress.selector);
+        vm.prank(opRewardAddr);
+        nodeRegistry.initiateRewardAddressChange(operatorAddr, newOPRewardAddr);
+
+        // it will pass if caller is address(0), which is not possible
+        vm.prank(address(0));
+        nodeRegistry.initiateRewardAddressChange(operatorAddr, newOPRewardAddr);
     }
 
     function test_updateOperatorRewardAddressWithZeroRewardAddr(string calldata _operatorName, uint64 __opAddrSeed)

--- a/test/foundry_tests/PermissionlessNodeRegistry.t.sol
+++ b/test/foundry_tests/PermissionlessNodeRegistry.t.sol
@@ -538,14 +538,14 @@ contract PermissionlessNodeRegistryTest is Test {
         string memory newOpName = string(abi.encodePacked(_operatorName, 'test'));
 
         // propose new reward addr
-        vm.expectRevert(INodeRegistry.OnlyExistingRewardAddressCanProposeNewRewardAddress.selector);
+        vm.expectRevert(INodeRegistry.CallerNotExistingRewardAddress.selector);
         vm.prank(operatorAddr);
         nodeRegistry.initiateRewardAddressChange(operatorAddr, newOPRewardAddr);
 
         vm.prank(opRewardAddr);
         nodeRegistry.initiateRewardAddressChange(operatorAddr, newOPRewardAddr);
 
-        address pendingRewardAddress = nodeRegistry.pendingRewardAddressByOperatorId(operatorId);
+        address pendingRewardAddress = nodeRegistry.proposedRewardAddressByOperatorId(operatorId);
         assertEq(pendingRewardAddress, newOPRewardAddr);
 
         // confirm new reward address
@@ -564,7 +564,9 @@ contract PermissionlessNodeRegistryTest is Test {
         assertEq(operatorRewardAddress, newOPRewardAddr);
     }
 
-    function test_updateOperatorDetailWithZeroRewardAddr(string calldata _operatorName, uint64 __opAddrSeed) public {
+    function test_updateOperatorRewardAddressWithZeroRewardAddr(string calldata _operatorName, uint64 __opAddrSeed)
+        public
+    {
         vm.assume(bytes(_operatorName).length > 0 && bytes(_operatorName).length < 255);
         vm.assume(__opAddrSeed > 0);
         address operatorAddr = vm.addr(__opAddrSeed);


### PR DESCRIPTION
- reward address change is a 2 step process now
- separated out reward address and opName change
- updated unit tests