### PR TITLE
feat/add SSV Pool

### DIFF
--- a/contracts/DVT/SSV/SSVNodeRegistry.sol
+++ b/contracts/DVT/SSV/SSVNodeRegistry.sol
@@ -1,0 +1,611 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.16;
+
+import '../../library/UtilLib.sol';
+import '../../library/ValidatorStatus.sol';
+
+import '../../interfaces/IPoolUtils.sol';
+import '../../interfaces/INodeRegistry.sol';
+import '../../interfaces/IStaderConfig.sol';
+import '../../interfaces/IVaultFactory.sol';
+
+import '../../interfaces/DVT/SSV/ISSVPool.sol';
+import '../../interfaces/IStaderInsuranceFund.sol';
+import '../../interfaces/SSVNetwork/ISSVNetwork.sol';
+import '../../interfaces/DVT/SSV/ISSVNodeRegistry.sol';
+import '../../interfaces/IOperatorRewardsCollector.sol';
+import '../../interfaces/SDCollateral/ISDCollateral.sol';
+import '../../interfaces/SSVNetwork/ISSVNetworkViews.sol';
+import '../../interfaces/DVT/SSV/ISSVValidatorWithdrawalVault.sol';
+
+import '@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol';
+
+contract SSVNodeRegistry is
+    ISSVNodeRegistry,
+    AccessControlUpgradeable,
+    PausableUpgradeable,
+    ReentrancyGuardUpgradeable
+{
+    uint8 public constant override POOL_ID = 3;
+    uint8 public constant override CLUSTER_SIZE = 4;
+    uint16 public override inputKeyCountLimit;
+    uint64 public batchSizeToRemoveValidatorFromSSV;
+    uint64 public batchSizeToRegisterValidatorFromSSV;
+
+    IStaderConfig public staderConfig;
+    ISSVNetwork public ssvNetwork;
+    ISSVNetworkViews public ssvNetworkViews;
+
+    uint64 public nextOperatorId;
+    uint256 public nextValidatorId;
+    uint256 public verifiedKeyBatchSize;
+    uint256 public nextQueuedValidatorIndex;
+    uint256 public totalActiveValidatorCount;
+    uint256 public constant COLLATERAL_ETH = 1.6 ether;
+    uint256 public constant COLLATERAL_ETH_PER_KEY_SHARE = 0.8 ether;
+
+    // mapping of validator Id and Validator struct
+    mapping(uint256 => Validator) public validatorRegistry;
+    // mapping of validator public key and validator Id
+    mapping(bytes => uint256) public validatorIdByPubkey;
+    //mapping of SSV operators assigned to a validator
+    mapping(bytes => uint64[]) public operatorIdssByPubkey;
+    // mapping of operator Id and Operator struct
+    mapping(uint64 => SSVOperator) public operatorStructById;
+    // mapping of operator address and operator Id
+    mapping(address => uint64) public operatorIDByAddress;
+    // mapping of whitelisted permissioned node operator
+    mapping(address => bool) public permissionList;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(
+        address _admin,
+        address _staderConfig,
+        address _ssvNetwork,
+        address _ssvNetworkViews
+    ) external initializer {
+        UtilLib.checkNonZeroAddress(_admin);
+        UtilLib.checkNonZeroAddress(_staderConfig);
+        UtilLib.checkNonZeroAddress(_ssvNetwork);
+        UtilLib.checkNonZeroAddress(_ssvNetworkViews);
+        __AccessControl_init_unchained();
+        __Pausable_init();
+        __ReentrancyGuard_init();
+        staderConfig = IStaderConfig(_staderConfig);
+        ssvNetwork = ISSVNetwork(_ssvNetwork);
+        ssvNetworkViews = ISSVNetworkViews(_ssvNetworkViews);
+        nextOperatorId = 1;
+        nextValidatorId = 1;
+        inputKeyCountLimit = 30;
+        verifiedKeyBatchSize = 50;
+        batchSizeToRemoveValidatorFromSSV = 10;
+        batchSizeToRegisterValidatorFromSSV = 10;
+        _grantRole(DEFAULT_ADMIN_ROLE, _admin);
+    }
+
+    /**
+     * @notice white list the permissioned node operator
+     * @dev only `MANAGER` can call, whitelisting a one way change there is no blacklisting
+     * @param _permissionedNOs array of permissioned NOs address
+     */
+    function whitelistPermissionedNOs(address[] calldata _permissionedNOs) external {
+        UtilLib.onlyManagerRole(msg.sender, staderConfig);
+        uint256 permissionedNosLength = _permissionedNOs.length;
+        for (uint256 i; i < permissionedNosLength; i++) {
+            address operator = _permissionedNOs[i];
+            UtilLib.checkNonZeroAddress(operator);
+            permissionList[operator] = true;
+            emit OperatorWhitelisted(operator);
+        }
+    }
+
+    /**
+     * @notice onboard a node operator
+     * @param _ssvOperatorID SSV defined ID of the operator
+     * @param _operatorName name of operator
+     * @param _operatorRewardAddress eth1 address of operator to get rewards and withdrawals
+     */
+    function onboardNodeOperator(
+        uint64 _ssvOperatorID,
+        string calldata _operatorName,
+        address payable _operatorRewardAddress
+    ) external whenNotPaused {
+        address poolUtils = staderConfig.getPoolUtils();
+        if (IPoolUtils(poolUtils).poolAddressById(POOL_ID) != staderConfig.getSSVPool()) {
+            revert DuplicatePoolIDOrPoolNotAdded();
+        }
+        IPoolUtils(poolUtils).onlyValidName(_operatorName);
+        UtilLib.checkNonZeroAddress(_operatorRewardAddress);
+        // verify weather operator is onboard with SSV along with being a private and active
+        // checks if operator has whitelisted this contract address
+        (address operatorOwner, , , address whitelisted, bool isPrivate, bool isActive) = ssvNetworkViews
+            .getOperatorById(_ssvOperatorID);
+        if (msg.sender != operatorOwner || whitelisted != address(this) || isPrivate != true || isActive != true) {
+            revert CallerFailingSSVOperatorChecks();
+        }
+        //checks if operator already onboarded in any pool of protocol
+        if (IPoolUtils(poolUtils).isExistingOperator(msg.sender)) {
+            revert OperatorAlreadyOnBoardedInProtocol();
+        }
+        operatorStructById[nextOperatorId] = SSVOperator(
+            permissionList[msg.sender],
+            _operatorName,
+            _operatorRewardAddress,
+            msg.sender,
+            _ssvOperatorID,
+            0,
+            0
+        );
+        operatorIDByAddress[msg.sender] = nextOperatorId;
+        nextOperatorId++;
+        emit SSVOperatorOnboard(msg.sender, nextOperatorId - 1);
+    }
+
+    /**
+     * @notice permissionless NO deposit collateral amount to run validators
+     * @dev allows only permissionless operator to add collateral
+     * amount of collateral should be multiple of collateral required per key-share
+     */
+    function depositCollateral() external payable {
+        uint64 operatorId = operatorIDByAddress[msg.sender];
+        _verifyOperatorAndDepositAmount(operatorId, msg.value);
+        operatorStructById[operatorId].bondAmount += msg.value;
+        emit BondDeposited(msg.sender, msg.value);
+    }
+
+    /**
+     * @notice add validator keys
+     * @dev only accepts call from stader `OPERATOR`
+     * @param _pubkey pubkey key of validators
+     * @param _preDepositSignature signature of a validators for 1ETH deposit
+     * @param _depositSignature signature of a validator for 31ETH deposit
+     */
+    function addValidatorKeys(
+        bytes[] calldata _pubkey,
+        bytes[] calldata _preDepositSignature,
+        bytes[] calldata _depositSignature
+    ) external whenNotPaused {
+        UtilLib.onlyOperatorRole(msg.sender, staderConfig);
+        uint256 keyCount = _pubkey.length;
+        _verifyAddValidatorsKeysInputParams(keyCount, _preDepositSignature.length, _depositSignature.length);
+        address vaultFactory = staderConfig.getVaultFactory();
+        address poolUtils = staderConfig.getPoolUtils();
+        for (uint256 i; i < keyCount; ) {
+            IPoolUtils(poolUtils).onlyValidKeys(_pubkey[i], _preDepositSignature[i], _depositSignature[i]);
+            address withdrawVault = IVaultFactory(vaultFactory).deploySSVValidatorWithdrawalVault(
+                POOL_ID,
+                nextValidatorId
+            );
+            validatorRegistry[nextValidatorId] = Validator(
+                ValidatorStatus.INITIALIZED,
+                _pubkey[i],
+                _preDepositSignature[i],
+                _depositSignature[i],
+                withdrawVault,
+                0,
+                0,
+                0
+            );
+            validatorIdByPubkey[_pubkey[i]] = nextValidatorId;
+            emit AddedValidatorKey(msg.sender, _pubkey[i], nextValidatorId);
+            nextValidatorId++;
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /**
+     * @notice move validator state from PRE_DEPOSIT to DEPOSIT
+     * after verifying pre-sign message, front running and deposit signature.
+     * report front run and invalid signature pubkeys
+     * @dev only stader oracle contract can call
+     * @param _readyToDepositPubkey array of pubkeys ready to be moved to DEPOSIT state
+     * @param _frontRunPubkey array for pubkeys which got front deposit
+     * @param _invalidSignaturePubkey array of pubkey which has invalid signature for deposit
+     */
+    function markValidatorReadyToDeposit(
+        bytes[] calldata _readyToDepositPubkey,
+        bytes[] calldata _frontRunPubkey,
+        bytes[] calldata _invalidSignaturePubkey
+    ) external nonReentrant whenNotPaused {
+        UtilLib.onlyStaderContract(msg.sender, staderConfig, staderConfig.STADER_ORACLE());
+        uint256 readyToDepositValidatorsLength = _readyToDepositPubkey.length;
+        uint256 frontRunValidatorsLength = _frontRunPubkey.length;
+        uint256 invalidSignatureValidatorsLength = _invalidSignaturePubkey.length;
+
+        if (
+            readyToDepositValidatorsLength + frontRunValidatorsLength + invalidSignatureValidatorsLength >
+            verifiedKeyBatchSize
+        ) {
+            revert TooManyVerifiedKeysReported();
+        }
+
+        //handle the front run validators
+        for (uint256 i; i < frontRunValidatorsLength; ) {
+            uint256 validatorId = validatorIdByPubkey[_frontRunPubkey[i]];
+            // only PRE_DEPOSIT status check will also include validatorId = 0 check
+            // as status for that will be INITIALIZED(default status)
+            _onlyPreDepositValidator(validatorId);
+            validatorRegistry[validatorId].status = ValidatorStatus.FRONT_RUN;
+            emit ValidatorMarkedAsFrontRunned(_frontRunPubkey[i], validatorId);
+            unchecked {
+                ++i;
+            }
+        }
+
+        //handle the invalid signature validators
+        for (uint256 i; i < invalidSignatureValidatorsLength; ) {
+            uint256 validatorId = validatorIdByPubkey[_invalidSignaturePubkey[i]];
+            // only PRE_DEPOSIT status check will also include validatorId = 0 check
+            // as status for that will be INITIALIZED(default status)
+            _onlyPreDepositValidator(validatorId);
+            validatorRegistry[validatorId].status = ValidatorStatus.INVALID_SIGNATURE;
+            emit ValidatorStatusMarkedAsInvalidSignature(_invalidSignaturePubkey[i], validatorId);
+            unchecked {
+                ++i;
+            }
+        }
+
+        address ssvPool = staderConfig.getSSVPool();
+        uint256 totalDefectedKeys = frontRunValidatorsLength + invalidSignatureValidatorsLength;
+        if (totalDefectedKeys > 0) {
+            _decreaseTotalActiveValidatorCount(totalDefectedKeys);
+            ISSVPool(ssvPool).transferETHOfDefectiveKeysToSSPM(totalDefectedKeys);
+        }
+        ISSVPool(ssvPool).fullDepositOnBeaconChain(_readyToDepositPubkey);
+    }
+
+    /**
+     * @notice register validator with SSV network
+     * @param publicKey array of validator public keys
+     * @param staderOperatorIds array of array of stader operator Ids
+     * @param sharesData array of sharesData
+     * @param cluster cluster array
+     */
+    function registerValidatorsWithSSV(
+        bytes[] calldata publicKey,
+        uint64[][] memory staderOperatorIds,
+        bytes[] calldata sharesData,
+        ISSVNetworkCore.Cluster[] memory cluster
+    ) external {
+        UtilLib.onlyOperatorRole(msg.sender, staderConfig);
+        uint256 keyCount = publicKey.length;
+        if (keyCount > batchSizeToRegisterValidatorFromSSV) {
+            revert InputSizeIsMoreThanBatchSize();
+        }
+        if (keyCount != staderOperatorIds.length || keyCount != sharesData.length || keyCount != cluster.length) {
+            revert MisMatchingInputKeysSize();
+        }
+        for (uint256 i; i < keyCount; ) {
+            operatorIdssByPubkey[publicKey[i]] = staderOperatorIds[i];
+            uint64[] memory ssvOperatorIds = _validateStaderOperators(staderOperatorIds[i]);
+            ssvNetwork.registerValidator(publicKey[i], ssvOperatorIds, sharesData[i], 0, cluster[i]);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /**
+     * @notice handling of fully withdrawn validators
+     * @dev list of pubkeys reported by oracle
+     * @param  _pubkeys array of withdrawn validators pubkey
+     */
+    function withdrawnValidators(bytes[] calldata _pubkeys) external {
+        UtilLib.onlyStaderContract(msg.sender, staderConfig, staderConfig.STADER_ORACLE());
+        uint256 withdrawnValidatorCount = _pubkeys.length;
+        if (withdrawnValidatorCount > staderConfig.getWithdrawnKeyBatchSize()) {
+            revert TooManyWithdrawnKeysReported();
+        }
+        for (uint256 i; i < withdrawnValidatorCount; ) {
+            uint256 validatorId = validatorIdByPubkey[_pubkeys[i]];
+            if (validatorRegistry[validatorId].status != ValidatorStatus.DEPOSITED) {
+                revert UNEXPECTED_STATUS();
+            }
+            _decreaseOperatorsKeyShareCount(_pubkeys[i]);
+            validatorRegistry[validatorId].status = ValidatorStatus.WITHDRAWN;
+            validatorRegistry[validatorId].withdrawnBlock = block.number;
+            ISSVValidatorWithdrawalVault(validatorRegistry[validatorId].withdrawVaultAddress).settleFunds();
+            emit ValidatorWithdrawn(_pubkeys[i], validatorId);
+            unchecked {
+                ++i;
+            }
+        }
+        _decreaseTotalActiveValidatorCount(withdrawnValidatorCount);
+    }
+
+    function removeValidatorFromSSVNetwork(bytes[] calldata publicKey, ISSVNetworkCore.Cluster[] memory cluster)
+        external
+    {
+        UtilLib.onlyOperatorRole(msg.sender, staderConfig);
+        if (publicKey.length > batchSizeToRemoveValidatorFromSSV) {
+            revert InputSizeIsMoreThanBatchSize();
+        }
+        for (uint256 i; i < publicKey.length; i++) {
+            uint256 validatorId = validatorIdByPubkey[publicKey[i]];
+            if (validatorRegistry[validatorId].status != ValidatorStatus.WITHDRAWN) {
+                revert ValidatorNotWithdrawn();
+            }
+            ssvNetwork.removeValidator(publicKey[i], operatorIdssByPubkey[publicKey[i]], cluster[i]);
+        }
+    }
+
+    /**
+     * @notice update the status of a validator to `PRE_DEPOSIT`
+     * @dev only `SSV_POOL` contract can call
+     * @param _pubkey pubkey of the validator
+     */
+    function markValidatorStatusAsPreDeposit(bytes calldata _pubkey) external {
+        UtilLib.onlyStaderContract(msg.sender, staderConfig, staderConfig.SSV_POOL());
+        uint256 validatorId = validatorIdByPubkey[_pubkey];
+        validatorRegistry[validatorId].status = ValidatorStatus.PRE_DEPOSIT;
+        emit MarkedValidatorStatusAsPreDeposit(_pubkey);
+    }
+
+    // function to set fee recipient address of all validator registered to SSV Network via this contract
+    function setFeeRecipientAddress() external {
+        ssvNetwork.setFeeRecipientAddress(staderConfig.getSSVSocializingPool());
+    }
+
+    /**
+     * @notice increase the total active validator count
+     * @dev only `SSV_POOL` calls it when it does the deposit of 1 ETH for validator
+     * @param _count count to increase total active validator value
+     */
+    function increaseTotalActiveValidatorCount(uint256 _count) external {
+        UtilLib.onlyStaderContract(msg.sender, staderConfig, staderConfig.SSV_POOL());
+        totalActiveValidatorCount += _count;
+        emit IncreasedTotalActiveValidatorCount(totalActiveValidatorCount);
+    }
+
+    /**
+     * @notice update the next queued validator index by a count
+     * @dev accept call from `SSV_POOL`
+     * @param _nextQueuedValidatorIndex updated next index of queued validator
+     */
+    function updateNextQueuedValidatorIndex(uint256 _nextQueuedValidatorIndex) external {
+        UtilLib.onlyStaderContract(msg.sender, staderConfig, staderConfig.SSV_POOL());
+        nextQueuedValidatorIndex = _nextQueuedValidatorIndex;
+        emit UpdatedNextQueuedValidatorIndex(nextQueuedValidatorIndex);
+    }
+
+    /**
+     * @notice update maximum key to be added in a batch
+     * @dev only `OPERATOR` role can call
+     * @param _inputKeyCountLimit updated maximum key limit in the input
+     */
+    function updateInputKeyCountLimit(uint16 _inputKeyCountLimit) external override {
+        UtilLib.onlyOperatorRole(msg.sender, staderConfig);
+        inputKeyCountLimit = _inputKeyCountLimit;
+        emit UpdatedInputKeyCountLimit(inputKeyCountLimit);
+    }
+
+    /**
+     * @notice update the batch size of the keys to remove from SSV Network
+     * @dev only `OPERATOR` role can call
+     * @param _batchSizeToRemoveValidatorFromSSV count of pubkey to remove from SSV Network in a batch
+     */
+    function updateBatchSizeToRemoveValidatorFromSSV(uint64 _batchSizeToRemoveValidatorFromSSV) external override {
+        UtilLib.onlyOperatorRole(msg.sender, staderConfig);
+        batchSizeToRemoveValidatorFromSSV = _batchSizeToRemoveValidatorFromSSV;
+        emit UpdatedBatchSizeToRemoveValidatorFromSSV(batchSizeToRemoveValidatorFromSSV);
+    }
+
+    /**
+     * @notice update the batch size of the keys to register with SSV Network
+     * @dev only `OPERATOR` role can call
+     * @param _batchSizeToRegisterValidatorFromSSV count of pubkey to register with SSV Network in a batch
+     */
+    function updateBatchSizeToRegisterValidatorFromSSV(uint64 _batchSizeToRegisterValidatorFromSSV) external override {
+        UtilLib.onlyOperatorRole(msg.sender, staderConfig);
+        batchSizeToRegisterValidatorFromSSV = _batchSizeToRegisterValidatorFromSSV;
+        emit UpdatedBatchSizeToRegisterValidatorWithSSV(batchSizeToRegisterValidatorFromSSV);
+    }
+
+    /**
+     * @notice update the max number of verified validator keys reported by oracle
+     * @dev only `OPERATOR` can call
+     * @param _verifiedKeysBatchSize updated maximum verified key limit in the oracle input
+     */
+    function updateVerifiedKeysBatchSize(uint256 _verifiedKeysBatchSize) external {
+        UtilLib.onlyOperatorRole(msg.sender, staderConfig);
+        verifiedKeyBatchSize = _verifiedKeysBatchSize;
+        emit UpdatedVerifiedKeyBatchSize(_verifiedKeysBatchSize);
+    }
+
+    /**
+     * @notice update the address of staderConfig
+     * @dev only `DEFAULT_ADMIN_ROLE` role can update
+     */
+    function updateStaderConfig(address _staderConfig) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        UtilLib.checkNonZeroAddress(_staderConfig);
+        staderConfig = IStaderConfig(_staderConfig);
+        emit UpdatedStaderConfig(_staderConfig);
+    }
+
+    // check for only PRE_DEPOSIT state validators
+    function onlyPreDepositValidator(bytes calldata _pubkey) external view {
+        uint256 validatorId = validatorIdByPubkey[_pubkey];
+        _onlyPreDepositValidator(validatorId);
+    }
+
+    // check for duplicate keys in permissionless node registry
+    function isExistingPubkey(bytes calldata _pubkey) external view override returns (bool) {
+        return validatorIdByPubkey[_pubkey] != 0;
+    }
+
+    // check for duplicate operator in permissionless node registry
+    function isExistingOperator(address _operAddr) external view override returns (bool) {
+        return operatorIDByAddress[_operAddr] != 0;
+    }
+
+    /**
+     * @notice returns total active validator for SSV pool
+     * @dev return the variable totalActiveValidatorCount
+     * @return _validatorCount active validator count
+     */
+    function getTotalActiveValidatorCount() external view returns (uint256) {
+        return totalActiveValidatorCount;
+    }
+
+    /**
+     * @notice returns total queued keys for ssv pool
+     * @return _validatorCount queued validator count
+     */
+    function getTotalQueuedValidatorCount() external view returns (uint256) {
+        return nextValidatorId - nextQueuedValidatorIndex;
+    }
+
+    function getCollateralETH() external pure returns (uint256) {
+        return COLLATERAL_ETH;
+    }
+
+    /**
+     * @notice get the total count of keyshare for an operator
+     * @param _operatorId Id of node operator
+     */
+    function getOperatorTotalKeys(uint256 _operatorId) public view override returns (uint256 _totalKeys) {
+        _totalKeys = operatorStructById[uint64(_operatorId)].keyShareCount;
+    }
+
+    /**
+     * @notice returns operator key share count, start and end index parameters are not use while computing this
+     * these params are defined to keep the function signature same as other pools
+     * pass any number in these params to get the number of key share of the operator
+     * @param _nodeOperator address of the operator
+     * @param _startIndex parameter defined to maintain integrity across other pools
+     * @param _endIndex parameter defined to maintain integrity across other pools
+     */
+    function getOperatorTotalNonTerminalKeys(
+        address _nodeOperator,
+        uint256 _startIndex,
+        uint256 _endIndex
+    ) external view returns (uint64) {
+        uint64 operatorId = operatorIDByAddress[_nodeOperator];
+        return operatorStructById[operatorId].keyShareCount;
+    }
+
+    function getOperatorsIdsForValidatorId(uint256 validatorId) external view returns (uint64[] memory) {
+        return operatorIdssByPubkey[validatorRegistry[validatorId].pubkey];
+    }
+
+    /**
+     * @notice Returns an array of active validators
+     *
+     * @param _pageNumber The page number of the results to fetch (starting from 1).
+     * @param _pageSize The maximum number of items per page.
+     *
+     * @return An array of `Validator` objects representing the active validators.
+     */
+    function getAllActiveValidators(uint256 _pageNumber, uint256 _pageSize) external view returns (Validator[] memory) {
+        if (_pageNumber == 0) {
+            revert PageNumberIsZero();
+        }
+        uint256 startIndex = (_pageNumber - 1) * _pageSize + 1;
+        uint256 endIndex = startIndex + _pageSize;
+        endIndex = endIndex > nextValidatorId ? nextValidatorId : endIndex;
+        Validator[] memory validators = new Validator[](_pageSize);
+        uint256 validatorCount;
+        for (uint256 i = startIndex; i < endIndex; i++) {
+            if (_isActiveValidator(i)) {
+                validators[validatorCount] = validatorRegistry[i];
+                validatorCount++;
+            }
+        }
+        // If the result array isn't full, resize it to remove the unused elements
+        assembly {
+            mstore(validators, validatorCount)
+        }
+
+        return validators;
+    }
+
+    // checks if validator is active,
+    //active validator are those having user deposit staked on beacon chain
+    function _isActiveValidator(uint256 _validatorId) internal view returns (bool) {
+        Validator memory validator = validatorRegistry[_validatorId];
+        return (validator.status == ValidatorStatus.PRE_DEPOSIT || validator.status == ValidatorStatus.DEPOSITED);
+    }
+
+    function _verifyOperatorAndDepositAmount(uint64 _operatorId, uint256 _depositAmount) internal view {
+        if (_operatorId == 0 || operatorStructById[_operatorId].operatorType) {
+            revert OperatorNotOnboardOrPermissioned();
+        }
+        if (_depositAmount % COLLATERAL_ETH_PER_KEY_SHARE != 0) {
+            revert InvalidCollateralAmount();
+        }
+    }
+
+    function _verifyAddValidatorsKeysInputParams(
+        uint256 _keyCount,
+        uint256 _preDepositSigLen,
+        uint256 _depositSigLen
+    ) internal view {
+        if (_keyCount != _preDepositSigLen || _keyCount != _depositSigLen) {
+            revert MisMatchingInputKeysSize();
+        }
+        if (_keyCount == 0 || _keyCount > inputKeyCountLimit) {
+            revert InvalidKeyCount();
+        }
+    }
+
+    function _validateStaderOperators(uint64[] memory staderOperatorIds)
+        internal
+        returns (uint64[] memory ssvOperatorIds)
+    {
+        if (staderOperatorIds.length != CLUSTER_SIZE) {
+            revert DifferentClusterSize();
+        }
+        ssvOperatorIds = new uint64[](CLUSTER_SIZE);
+        uint256 totalCollateral;
+        for (uint64 j = 0; j < CLUSTER_SIZE; j++) {
+            SSVOperator storage operator = operatorStructById[staderOperatorIds[j]];
+            bool enoughSDCollateral = ISDCollateral(staderConfig.getSDCollateral()).hasEnoughSDCollateral(
+                msg.sender,
+                POOL_ID,
+                operator.keyShareCount + 1
+            );
+            if (!operator.operatorType && (operator.bondAmount < COLLATERAL_ETH_PER_KEY_SHARE || !enoughSDCollateral)) {
+                revert NotSufficientCollateralPerKeyShare();
+            }
+            if (!operator.operatorType) {
+                totalCollateral += COLLATERAL_ETH_PER_KEY_SHARE;
+            }
+            operator.bondAmount -= COLLATERAL_ETH_PER_KEY_SHARE;
+            operator.keyShareCount += 1;
+            ssvOperatorIds[j] = operatorStructById[staderOperatorIds[j]].operatorSSVID;
+        }
+        if (totalCollateral != COLLATERAL_ETH) {
+            revert NotSufficientCollateralPerValidator();
+        }
+    }
+
+    function _onlyPreDepositValidator(uint256 _validatorId) internal view {
+        if (validatorRegistry[_validatorId].status != ValidatorStatus.PRE_DEPOSIT) {
+            revert UNEXPECTED_STATUS();
+        }
+    }
+
+    // decreases the pool total active validator count
+    function _decreaseTotalActiveValidatorCount(uint256 _count) internal {
+        totalActiveValidatorCount -= _count;
+        emit DecreasedTotalActiveValidatorCount(totalActiveValidatorCount);
+    }
+
+    function _decreaseOperatorsKeyShareCount(bytes calldata pubkey) internal {
+        uint64[] memory operatorIds = operatorIdssByPubkey[pubkey];
+        for (uint256 j; j < operatorIds.length; ) {
+            operatorStructById[operatorIds[j]].keyShareCount -= 1;
+            unchecked {
+                ++j;
+            }
+        }
+    }
+}

--- a/contracts/DVT/SSV/SSVPool.sol
+++ b/contracts/DVT/SSV/SSVPool.sol
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.16;
+
+import '../../library/UtilLib.sol';
+
+import '../../library/ValidatorStatus.sol';
+
+import '../../interfaces/IStaderConfig.sol';
+import '../../interfaces/IVaultFactory.sol';
+import '../../interfaces/IDepositContract.sol';
+import '../../interfaces/DVT/SSV/ISSVPool.sol';
+import '../../interfaces/IStaderInsuranceFund.sol';
+import '../../interfaces/IStaderStakePoolManager.sol';
+import '../../interfaces/DVT/SSV/ISSVNodeRegistry.sol';
+
+import '@openzeppelin/contracts/utils/math/Math.sol';
+import '@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol';
+
+contract SSVPool is ISSVPool, AccessControlUpgradeable, ReentrancyGuardUpgradeable {
+    using Math for uint256;
+
+    IStaderConfig public staderConfig;
+    // @inheritdoc IStaderPoolBase
+    uint256 public override protocolFee;
+
+    // @inheritdoc IStaderPoolBase
+    uint256 public override operatorFee;
+
+    uint256 public preDepositValidatorCount;
+
+    uint256 public constant MAX_COMMISSION_LIMIT_BIPS = 1500;
+
+    uint256 public constant DEPOSIT_NODE_BOND = 1.6 ether;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address _admin, address _staderConfig) external initializer {
+        UtilLib.checkNonZeroAddress(_admin);
+        UtilLib.checkNonZeroAddress(_staderConfig);
+        __AccessControl_init_unchained();
+        __ReentrancyGuard_init();
+        protocolFee = 500;
+        operatorFee = 500;
+        staderConfig = IStaderConfig(_staderConfig);
+        _grantRole(DEFAULT_ADMIN_ROLE, _admin);
+    }
+
+    function receiveInsuranceFund() external payable {
+        UtilLib.onlyStaderContract(msg.sender, staderConfig, staderConfig.STADER_INSURANCE_FUND());
+        emit ReceivedInsuranceFund(msg.value);
+    }
+
+    // transfer the 32ETH for defective keys (front run, invalid signature) to stader stake pool manager (SSPM)
+    function transferETHOfDefectiveKeysToSSPM(uint256 _defectiveKeyCount) external nonReentrant {
+        UtilLib.onlyStaderContract(msg.sender, staderConfig, staderConfig.SSV_NODE_REGISTRY());
+        //decrease the preDeposit validator count
+        _decreasePreDepositValidatorCount(_defectiveKeyCount);
+        //get 1ETH from insurance fund
+        IStaderInsuranceFund(staderConfig.getStaderInsuranceFund()).reimburseUserFund(
+            _defectiveKeyCount * staderConfig.getPreDepositSize()
+        );
+        // send back 30.4 ETH (32 - collateral) for front run and invalid signature validators back to pool manager
+        // These counts are correct because any double reporting of frontrun/invalid statuses results in an error.
+        uint256 amountToSendToPoolManager = _defectiveKeyCount *
+            (staderConfig.getStakedEthPerNode() - DEPOSIT_NODE_BOND);
+        //slither-disable-next-line arbitrary-send-eth
+        IStaderStakePoolManager(staderConfig.getStakePoolManager()).receiveExcessEthFromPool{
+            value: amountToSendToPoolManager
+        }(INodeRegistry((staderConfig).getSSVNodeRegistry()).POOL_ID());
+        emit TransferredETHToSSPMForDefectiveKeys(amountToSendToPoolManager);
+    }
+
+    /**
+     * @notice receives eth from pool manager to deposit for validators on beacon chain
+     * @dev deposit PRE_DEPOSIT_SIZE of ETH for validators while adhering to pool capacity.
+     */
+    function stakeUserETHToBeaconChain() external payable override nonReentrant {
+        UtilLib.onlyStaderContract(msg.sender, staderConfig, staderConfig.STAKE_POOL_MANAGER());
+        uint256 requiredValidators = msg.value / (staderConfig.getStakedEthPerNode() - DEPOSIT_NODE_BOND);
+        address nodeRegistryAddress = staderConfig.getSSVNodeRegistry();
+
+        address vaultFactoryAddress = staderConfig.getVaultFactory();
+        address ethDepositContract = staderConfig.getETHDepositContract();
+        uint256 depositQueueStartIndex = ISSVNodeRegistry(nodeRegistryAddress).nextQueuedValidatorIndex();
+        for (uint256 i = depositQueueStartIndex; i < requiredValidators + depositQueueStartIndex; ) {
+            _preDepositOnBeaconChain(nodeRegistryAddress, vaultFactoryAddress, ethDepositContract, i);
+            unchecked {
+                ++i;
+            }
+        }
+        ISSVNodeRegistry(nodeRegistryAddress).updateNextQueuedValidatorIndex(
+            depositQueueStartIndex + requiredValidators
+        );
+        _increasePreDepositValidatorCount(requiredValidators);
+        ISSVNodeRegistry(nodeRegistryAddress).increaseTotalActiveValidatorCount(requiredValidators);
+    }
+
+    // deposit `FULL_DEPOSIT_SIZE` for the verified preDeposited Validator
+    function fullDepositOnBeaconChain(bytes[] calldata _pubkey) external nonReentrant {
+        UtilLib.onlyStaderContract(msg.sender, staderConfig, staderConfig.SSV_NODE_REGISTRY());
+        address nodeRegistryAddress = msg.sender;
+        address vaultFactory = staderConfig.getVaultFactory();
+        address ethDepositContract = staderConfig.getETHDepositContract();
+        uint256 pubkeyCount = _pubkey.length;
+        //decrease the preDeposit validator count
+        _decreasePreDepositValidatorCount(pubkeyCount);
+        for (uint256 i; i < pubkeyCount; ) {
+            ISSVNodeRegistry(nodeRegistryAddress).onlyPreDepositValidator(_pubkey[i]);
+            uint256 validatorId = INodeRegistry(nodeRegistryAddress).validatorIdByPubkey(_pubkey[i]);
+            (, , , bytes memory depositSignature, address withdrawVaultAddress, , , ) = INodeRegistry(
+                nodeRegistryAddress
+            ).validatorRegistry(validatorId);
+            bytes memory withdrawCredential = IVaultFactory(vaultFactory).getValidatorWithdrawCredential(
+                withdrawVaultAddress
+            );
+            uint256 fullDepositSize = staderConfig.getFullDepositSize();
+            bytes32 depositDataRoot = this.computeDepositDataRoot(
+                _pubkey[i],
+                depositSignature,
+                withdrawCredential,
+                fullDepositSize
+            );
+
+            //slither-disable-next-line arbitrary-send-eth
+            IDepositContract(ethDepositContract).deposit{value: fullDepositSize}(
+                _pubkey[i],
+                withdrawCredential,
+                depositSignature,
+                depositDataRoot
+            );
+            // ISSVNodeRegistry(nodeRegistryAddress).updateDepositStatusAndBlock(validatorId);
+            emit ValidatorDepositedOnBeaconChain(validatorId, _pubkey[i]);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /**
+     * @notice transfer the excess ETH sent by some EAO or non stader contract back to SSPM
+     * @dev preDepositValidatorCount has to be 0 for determining excess ETH value
+     */
+    function transferExcessETHToSSPM() external nonReentrant {
+        if (preDepositValidatorCount != 0 || address(this).balance == 0) {
+            revert CouldNotDetermineExcessETH();
+        }
+        IStaderStakePoolManager(staderConfig.getStakePoolManager()).receiveExcessEthFromPool{
+            value: address(this).balance
+        }(INodeRegistry((staderConfig).getSSVNodeRegistry()).POOL_ID());
+    }
+
+    function getNodeRegistry() external view override returns (address) {
+        return staderConfig.getSSVNodeRegistry();
+    }
+
+    // @inheritdoc IStaderPoolBase
+    function getSocializingPoolAddress() external view returns (address) {
+        return staderConfig.getSSVSocializingPool();
+    }
+
+    // @inheritdoc IStaderPoolBase
+    function setCommissionFees(uint256 _protocolFee, uint256 _operatorFee) external {
+        UtilLib.onlyManagerRole(msg.sender, staderConfig);
+        if (_protocolFee + _operatorFee > MAX_COMMISSION_LIMIT_BIPS) {
+            revert InvalidCommission();
+        }
+        protocolFee = _protocolFee;
+        operatorFee = _operatorFee;
+
+        emit UpdatedCommissionFees(_protocolFee, _operatorFee);
+    }
+
+    //update the address of staderConfig
+    function updateStaderConfig(address _staderConfig) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        UtilLib.checkNonZeroAddress(_staderConfig);
+        staderConfig = IStaderConfig(_staderConfig);
+        emit UpdatedStaderConfig(_staderConfig);
+    }
+
+    // @notice calculate the deposit data root based on pubkey, signature, withdrawCredential and amount
+    // formula based on ethereum deposit contract
+    function computeDepositDataRoot(
+        bytes calldata _pubkey,
+        bytes calldata _signature,
+        bytes calldata _withdrawCredential,
+        uint256 _depositAmount
+    ) external pure returns (bytes32) {
+        bytes memory amount = to_little_endian_64(_depositAmount);
+        bytes32 pubkey_root = sha256(abi.encodePacked(_pubkey, bytes16(0)));
+        bytes32 signature_root = sha256(
+            abi.encodePacked(
+                sha256(abi.encodePacked(_signature[:64])),
+                sha256(abi.encodePacked(_signature[64:], bytes32(0)))
+            )
+        );
+        return
+            sha256(
+                abi.encodePacked(
+                    sha256(abi.encodePacked(pubkey_root, _withdrawCredential)),
+                    sha256(abi.encodePacked(amount, bytes24(0), signature_root))
+                )
+            );
+    }
+
+    function _increasePreDepositValidatorCount(uint256 _count) internal {
+        preDepositValidatorCount += _count;
+    }
+
+    function _decreasePreDepositValidatorCount(uint256 _count) internal {
+        preDepositValidatorCount -= _count;
+    }
+
+    // deposit `PRE_DEPOSIT_SIZE` for validator
+    function _preDepositOnBeaconChain(
+        address _nodeRegistryAddress,
+        address _vaultFactory,
+        address _ethDepositContract,
+        uint256 _validatorId
+    ) internal {
+        (, bytes memory pubkey, bytes memory preDepositSignature, , address withdrawVaultAddress, , , ) = INodeRegistry(
+            _nodeRegistryAddress
+        ).validatorRegistry(_validatorId);
+
+        bytes memory withdrawCredential = IVaultFactory(_vaultFactory).getValidatorWithdrawCredential(
+            withdrawVaultAddress
+        );
+        uint256 preDepositSize = staderConfig.getPreDepositSize();
+        bytes32 depositDataRoot = this.computeDepositDataRoot(
+            pubkey,
+            preDepositSignature,
+            withdrawCredential,
+            preDepositSize
+        );
+
+        //slither-disable-next-line arbitrary-send-eth
+        IDepositContract(_ethDepositContract).deposit{value: preDepositSize}(
+            pubkey,
+            withdrawCredential,
+            preDepositSignature,
+            depositDataRoot
+        );
+        ISSVNodeRegistry(_nodeRegistryAddress).markValidatorStatusAsPreDeposit(pubkey);
+        emit ValidatorPreDepositedOnBeaconChain(pubkey);
+    }
+
+    //ethereum deposit contract function to get amount into little_endian_64
+    function to_little_endian_64(uint256 _depositAmount) internal pure returns (bytes memory ret) {
+        uint64 value = uint64(_depositAmount / 1 gwei);
+
+        ret = new bytes(8);
+        bytes8 bytesValue = bytes8(value);
+        // Byteswapping during copying to bytes.
+        ret[0] = bytesValue[7];
+        ret[1] = bytesValue[6];
+        ret[2] = bytesValue[5];
+        ret[3] = bytesValue[4];
+        ret[4] = bytesValue[3];
+        ret[5] = bytesValue[2];
+        ret[6] = bytesValue[1];
+        ret[7] = bytesValue[0];
+    }
+}

--- a/contracts/DVT/SSV/SSVValidatorWithdrawalVault.sol
+++ b/contracts/DVT/SSV/SSVValidatorWithdrawalVault.sol
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.16;
+
+import '../../library/UtilLib.sol';
+import './SSVVaultProxy.sol';
+import '../../interfaces/IPenalty.sol';
+import '../../interfaces/IPoolUtils.sol';
+import '../../interfaces/IStaderStakePoolManager.sol';
+import '../../interfaces/DVT/SSV/ISSVNodeRegistry.sol';
+import '../../interfaces/IOperatorRewardsCollector.sol';
+import '../../interfaces/SDCollateral/ISDCollateral.sol';
+import '../../interfaces/DVT/SSV/ISSVValidatorWithdrawalVault.sol';
+
+import '@openzeppelin/contracts/utils/math/Math.sol';
+
+contract SSVValidatorWithdrawalVault is ISSVValidatorWithdrawalVault {
+    bool internal vaultSettleStatus;
+    using Math for uint256;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {}
+
+    // Allows the contract to receive ETH
+    receive() external payable {
+        emit ETHReceived(msg.sender, msg.value);
+    }
+
+    function distributeRewards() external override {
+        uint8 poolId = SSVVaultProxy(payable(address(this))).poolId();
+        uint256 validatorId = SSVVaultProxy(payable(address(this))).validatorId();
+        IStaderConfig staderConfig = SSVVaultProxy(payable(address(this))).staderConfig();
+        ISSVNodeRegistry nodeRegistry = ISSVNodeRegistry(
+            IPoolUtils(staderConfig.getPoolUtils()).getNodeRegistry(poolId)
+        );
+
+        uint256 totalRewards = address(this).balance;
+        if (!staderConfig.onlyManagerRole(msg.sender) && totalRewards > staderConfig.getRewardsThreshold()) {
+            emit DistributeRewardFailed(totalRewards, staderConfig.getRewardsThreshold());
+            revert InvalidRewardAmount();
+        }
+        if (totalRewards == 0) {
+            revert NotEnoughRewardToDistribute();
+        }
+        (uint256 userShare, uint256 operatorShare, uint256 protocolShare) = IPoolUtils(staderConfig.getPoolUtils())
+            .calculateRewardShare(poolId, totalRewards);
+
+        //TODO how to make sure only 4 operators
+        //TODO pull this number 4 from somewhere maybe ssv node registry
+        //TODO add documentation for this formula
+        // Distribute rewards
+        uint64[] memory operatorIds = nodeRegistry.getOperatorsIdsForValidatorId(validatorId);
+        uint256 totalOperators = operatorIds.length;
+        for (uint8 i; i < totalOperators; ) {
+            (bool operatorType, , , address operatorAddress, , , ) = nodeRegistry.operatorStructById(operatorIds[i]);
+            uint256 operatorKeyLevelShare;
+            if (operatorType) {
+                operatorKeyLevelShare = getPermissionedOperatorShare(
+                    operatorShare,
+                    totalRewards,
+                    nodeRegistry.getCollateralETH(),
+                    staderConfig.getStakedEthPerNode()
+                );
+            } else {
+                operatorKeyLevelShare = getPermissionlessOperatorShare(
+                    operatorShare,
+                    totalRewards,
+                    nodeRegistry.getCollateralETH(),
+                    staderConfig.getStakedEthPerNode()
+                );
+            }
+            IOperatorRewardsCollector(staderConfig.getOperatorRewardsCollector()).depositFor{
+                value: operatorKeyLevelShare
+            }(operatorAddress);
+            unchecked {
+                i++;
+            }
+        }
+        IStaderStakePoolManager(staderConfig.getStakePoolManager()).receiveWithdrawVaultUserShare{value: userShare}();
+        UtilLib.sendValue(payable(staderConfig.getStaderTreasury()), protocolShare);
+        emit DistributedRewards(userShare, operatorShare, protocolShare);
+    }
+
+    function settleFunds() external override {
+        uint8 poolId = SSVVaultProxy(payable(address(this))).poolId();
+        uint256 validatorId = SSVVaultProxy(payable(address(this))).validatorId();
+        IStaderConfig staderConfig = SSVVaultProxy(payable(address(this))).staderConfig();
+        if (msg.sender != IPoolUtils(staderConfig.getPoolUtils()).getNodeRegistry(poolId)) {
+            revert CallerNotNodeRegistryContract();
+        }
+        uint64[] memory operatorIds = ISSVNodeRegistry(msg.sender).getOperatorsIdsForValidatorId(validatorId);
+        uint256 totalOperators = operatorIds.length;
+
+        (uint256 userSharePrelim, uint256 operatorShare, uint256 protocolShare) = calculateValidatorWithdrawalShare(
+            poolId,
+            staderConfig
+        );
+
+        uint256 penaltyAmount = getUpdatedPenaltyAmount(validatorId, staderConfig);
+        uint256 permissionedOperatorShare;
+        uint256 permissionlessOperatorShare;
+        uint256 collateralETH = ISSVNodeRegistry(msg.sender).getCollateralETH();
+        if (operatorShare <= collateralETH) {
+            permissionlessOperatorShare = operatorShare / 2;
+        } else {
+            uint256 rewards = address(this).balance - staderConfig.getStakedEthPerNode();
+            permissionedOperatorShare = getPermissionedOperatorShare(
+                operatorShare - collateralETH,
+                rewards,
+                collateralETH,
+                staderConfig.getStakedEthPerNode()
+            );
+
+            permissionlessOperatorShare =
+                collateralETH /
+                2 +
+                getPermissionlessOperatorShare(
+                    operatorShare - collateralETH,
+                    rewards,
+                    collateralETH,
+                    staderConfig.getStakedEthPerNode()
+                );
+        }
+
+        if (operatorShare < penaltyAmount) {
+            //slash SD of permissionless operators
+            ISDCollateral(staderConfig.getSDCollateral()).slashSSVOperatorSD(poolId, validatorId, operatorIds);
+            penaltyAmount = operatorShare;
+        }
+        uint256 userShare = userSharePrelim + penaltyAmount;
+
+        if (penaltyAmount >= 4 * permissionedOperatorShare) {
+            permissionlessOperatorShare -= (penaltyAmount - 2 * permissionedOperatorShare) / 2;
+            permissionedOperatorShare = 0;
+        } else {
+            permissionedOperatorShare -= penaltyAmount / 4;
+            permissionlessOperatorShare -= penaltyAmount / 4;
+        }
+
+        // Final settlement
+        vaultSettleStatus = true;
+        IPenalty(staderConfig.getPenaltyContract()).markValidatorSettled(poolId, validatorId);
+        IStaderStakePoolManager(staderConfig.getStakePoolManager()).receiveWithdrawVaultUserShare{value: userShare}();
+        UtilLib.sendValue(payable(staderConfig.getStaderTreasury()), protocolShare);
+        for (uint8 i; i < totalOperators; i++) {
+            (bool operatorType, , , address operatorAddress, , , ) = ISSVNodeRegistry(msg.sender).operatorStructById(
+                operatorIds[i]
+            );
+            if (operatorType) {
+                IOperatorRewardsCollector(staderConfig.getOperatorRewardsCollector()).depositFor{
+                    value: permissionedOperatorShare
+                }(operatorAddress);
+            } else {
+                IOperatorRewardsCollector(staderConfig.getOperatorRewardsCollector()).depositFor{
+                    value: permissionlessOperatorShare
+                }(operatorAddress);
+            }
+        }
+        emit SettledFunds(userShare, operatorShare, protocolShare);
+    }
+
+    function calculateValidatorWithdrawalShare(uint8 _poolId, IStaderConfig _staderConfig)
+        public
+        view
+        returns (
+            uint256 userShare,
+            uint256 operatorShare,
+            uint256 protocolShare
+        )
+    {
+        uint256 TOTAL_STAKED_ETH = _staderConfig.getStakedEthPerNode();
+        uint256 collateralETH = ISSVNodeRegistry(msg.sender).getCollateralETH();
+        uint256 usersETH = TOTAL_STAKED_ETH - collateralETH;
+        uint256 contractBalance = address(this).balance;
+
+        uint256 totalRewards;
+
+        if (contractBalance <= usersETH) {
+            userShare = contractBalance;
+            return (userShare, operatorShare, protocolShare);
+        } else if (contractBalance <= TOTAL_STAKED_ETH) {
+            userShare = usersETH;
+            operatorShare = contractBalance - userShare;
+            return (userShare, operatorShare, protocolShare);
+        } else {
+            totalRewards = contractBalance - TOTAL_STAKED_ETH;
+            operatorShare = collateralETH;
+            userShare = usersETH;
+        }
+        if (totalRewards > 0) {
+            (uint256 userReward, uint256 operatorReward, uint256 protocolReward) = IPoolUtils(
+                _staderConfig.getPoolUtils()
+            ).calculateRewardShare(_poolId, totalRewards);
+            userShare += userReward;
+            operatorShare += operatorReward;
+            protocolShare += protocolReward;
+        }
+    }
+
+    // HELPER METHODS
+
+    function getUpdatedPenaltyAmount(uint256 _validatorId, IStaderConfig _staderConfig) internal returns (uint256) {
+        (, bytes memory pubkey, , , , , , ) = ISSVNodeRegistry(msg.sender).validatorRegistry(_validatorId);
+        bytes[] memory pubkeyArray = new bytes[](1);
+        pubkeyArray[0] = pubkey;
+        IPenalty(_staderConfig.getPenaltyContract()).updateTotalPenaltyAmount(pubkeyArray);
+        return IPenalty(_staderConfig.getPenaltyContract()).totalPenaltyAmount(pubkey);
+    }
+
+    function getPermissionedOperatorShare(
+        uint256 operatorShare,
+        uint256 rewards,
+        uint256 collateralETH,
+        uint256 ETH_PER_NODE
+    ) internal pure returns (uint256) {
+        return (operatorShare - (rewards * collateralETH) / ETH_PER_NODE) / 4;
+    }
+
+    function getPermissionlessOperatorShare(
+        uint256 operatorShare,
+        uint256 rewards,
+        uint256 collateralETH,
+        uint256 ETH_PER_NODE
+    ) internal pure returns (uint256) {
+        return (operatorShare + (rewards * collateralETH) / ETH_PER_NODE) / 4;
+    }
+}

--- a/contracts/DVT/SSV/SSVVaultProxy.sol
+++ b/contracts/DVT/SSV/SSVVaultProxy.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.16;
+
+import '../../library/UtilLib.sol';
+import '../../interfaces/DVT/SSV/ISSVVaultProxy.sol';
+
+//contract to delegate call to ssv validator withdraw vault implementation
+contract SSVVaultProxy is ISSVVaultProxy {
+    bool public override vaultSettleStatus;
+    bool public override isInitialized;
+    uint8 public override poolId;
+    uint256 public override validatorId;
+    address public override owner;
+    IStaderConfig public override staderConfig;
+
+    constructor() {
+        isInitialized = true;
+    }
+
+    //initialise the vault proxy with data
+    function initialise(
+        uint8 _poolId,
+        uint256 _validatorId,
+        address _staderConfig
+    ) external {
+        if (isInitialized) {
+            revert AlreadyInitialized();
+        }
+        UtilLib.checkNonZeroAddress(_staderConfig);
+        isInitialized = true;
+        poolId = _poolId;
+        validatorId = _validatorId;
+        staderConfig = IStaderConfig(_staderConfig);
+        owner = staderConfig.getAdmin();
+        UtilLib.checkNonZeroAddress(owner);
+    }
+
+    /**route all call to this proxy contract to the latest SSV validator withdrawl vault contract
+     * fetched from staderConfig. This approach will help in changing the implementation
+     * of ssv validator's withdrawal vault for already deployed vaults*/
+    fallback(bytes calldata _input) external payable returns (bytes memory) {
+        (bool success, bytes memory data) = (staderConfig.getSSVValidatorWithdrawalVault()).delegatecall(_input);
+        if (!success) {
+            revert(string(data));
+        }
+        return data;
+    }
+
+    /**
+     * @notice update the address of stader config contract
+     * @dev only owner can call
+     * @param _staderConfig address of updated staderConfig
+     */
+    function updateStaderConfig(address _staderConfig) external override onlyOwner {
+        UtilLib.checkNonZeroAddress(_staderConfig);
+        staderConfig = IStaderConfig(_staderConfig);
+        emit UpdatedStaderConfig(_staderConfig);
+    }
+
+    // update the owner of vault proxy contract to staderConfig Admin
+    function updateOwner() external override {
+        owner = staderConfig.getAdmin();
+        emit UpdatedOwner(owner);
+    }
+
+    //modifier to check only owner
+    modifier onlyOwner() {
+        if (msg.sender != owner) {
+            revert CallerNotOwner();
+        }
+        _;
+    }
+}

--- a/contracts/SDCollateral.sol
+++ b/contracts/SDCollateral.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.16;
 import './library/UtilLib.sol';
 
 import '../contracts/interfaces/IPoolUtils.sol';
+import '../contracts/interfaces/DVT/SSV/ISSVNodeRegistry.sol';
 import '../contracts/interfaces/SDCollateral/ISDCollateral.sol';
 import '../contracts/interfaces/SDCollateral/IAuction.sol';
 import '../contracts/interfaces/IStaderOracle.sol';
@@ -78,6 +79,32 @@ contract SDCollateral is ISDCollateral, AccessControlUpgradeable, ReentrancyGuar
         PoolThresholdInfo storage poolThreshold = poolThresholdbyPoolId[_poolId];
         uint256 sdToSlash = convertETHToSD(poolThreshold.minThreshold);
         slashSD(operator, sdToSlash);
+    }
+
+    /// @notice slashes one validator equi. SD amount
+    /// @dev callable only by respective withdrawVaults
+    /// @param _validatorId validator SD collateral to slash
+    function slashSSVOperatorSD(
+        uint8 _poolId,
+        uint256 _validatorId,
+        uint64[] memory operatorIds
+    ) external override nonReentrant {
+        (, , , , address withdrawVaultAddress, , , ) = INodeRegistry(
+            IPoolUtils(staderConfig.getPoolUtils()).getNodeRegistry(_poolId)
+        ).validatorRegistry(_validatorId);
+        if (msg.sender != withdrawVaultAddress) {
+            revert CallerNotWithdrawVault();
+        }
+        isPoolThresholdValid(_poolId);
+        uint256 sdToSlash = convertETHToSD(poolThresholdbyPoolId[_poolId].minThreshold);
+        for (uint8 i; i < operatorIds.length; i++) {
+            (bool operatorType, , , address operatorAddress, , , ) = ISSVNodeRegistry(msg.sender).operatorStructById(
+                operatorIds[i]
+            );
+            if (!operatorType) {
+                slashSD(operatorAddress, convertETHToSD(sdToSlash));
+            }
+        }
     }
 
     /// @notice used to slash operator SD, incase of operator default

--- a/contracts/StaderConfig.sol
+++ b/contracts/StaderConfig.sol
@@ -77,6 +77,12 @@ contract StaderConfig is IStaderConfig, AccessControlUpgradeable {
     mapping(bytes32 => address) private contractsMap;
     mapping(bytes32 => address) private tokensMap;
 
+    //SSV Pool
+    bytes32 public constant override SSV_POOL = keccak256('SSV_POOL');
+    bytes32 public constant override SSV_NODE_REGISTRY = keccak256('SSV_NODE_REGISTRY');
+    bytes32 public constant override SSV_SOCIALIZING_POOL = keccak256('SSV_SOCIALIZING_POOL');
+    bytes32 public constant override SSV_VALIDATOR_WITHDRAWAL_VAULT = keccak256('SSV_VALIDATOR_WITHDRAWAL_VAULT');
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
@@ -292,6 +298,25 @@ contract StaderConfig is IStaderConfig, AccessControlUpgradeable {
         setToken(ETHx, _ethX);
     }
 
+    function updateSSVPool(address _ssvPool) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        setContract(SSV_POOL, _ssvPool);
+    }
+
+    function updateSSVNodeRegistry(address _ssvNodeRegistry) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        setContract(SSV_NODE_REGISTRY, _ssvNodeRegistry);
+    }
+
+    function updateSSVSocializingPool(address _ssvSocializingPool) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        setContract(SSV_SOCIALIZING_POOL, _ssvSocializingPool);
+    }
+
+    function updateSSVValidatorWithdrawalVault(address _ssvValidatorWithdrawalVault)
+        external
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        setContract(SSV_VALIDATOR_WITHDRAWAL_VAULT, _ssvValidatorWithdrawalVault);
+    }
+
     //Constants Getters
 
     function getStakedEthPerNode() external view override returns (uint256) {
@@ -446,6 +471,22 @@ contract StaderConfig is IStaderConfig, AccessControlUpgradeable {
 
     function getValidatorWithdrawalVaultImplementation() external view override returns (address) {
         return contractsMap[VALIDATOR_WITHDRAWAL_VAULT_IMPLEMENTATION];
+    }
+
+    function getSSVPool() external view override returns (address) {
+        return contractsMap[SSV_POOL];
+    }
+
+    function getSSVNodeRegistry() external view override returns (address) {
+        return contractsMap[SSV_NODE_REGISTRY];
+    }
+
+    function getSSVSocializingPool() external view override returns (address) {
+        return contractsMap[SSV_SOCIALIZING_POOL];
+    }
+
+    function getSSVValidatorWithdrawalVault() external view override returns (address) {
+        return contractsMap[SSV_VALIDATOR_WITHDRAWAL_VAULT];
     }
 
     //POR Feed Proxy Getters

--- a/contracts/StaderInsuranceFund.sol
+++ b/contracts/StaderInsuranceFund.sol
@@ -48,16 +48,18 @@ contract StaderInsuranceFund is IStaderInsuranceFund, AccessControlUpgradeable, 
     }
 
     /**
-     * @notice reimburse 1 ETH per key to SSPM for permissioned NOs doing front running or giving invalid signature
-     * @dev only permissioned pool can call
-     * @param _amount amount of ETH to transfer to permissioned pool
+     * @notice reimburse 1 ETH per key to SSPM for permissioned/SSV NOs doing front running or giving invalid signature
+     * @dev only permissioned/SSV pool can call
+     * @param _amount amount of ETH to transfer to permissioned/SSV pool
      */
     function reimburseUserFund(uint256 _amount) external override nonReentrant {
-        UtilLib.onlyStaderContract(msg.sender, staderConfig, staderConfig.PERMISSIONED_POOL());
+        if (msg.sender != staderConfig.getPermissionedPool() || msg.sender != staderConfig.getSSVPool()) {
+            revert InvalidPoolToReimburse();
+        }
         if (address(this).balance < _amount) {
             revert InSufficientBalance();
         }
-        IPermissionedPool(staderConfig.getPermissionedPool()).receiveInsuranceFund{value: _amount}();
+        IPermissionedPool(msg.sender).receiveInsuranceFund{value: _amount}();
     }
 
     //update the address of staderConfig

--- a/contracts/factory/VaultFactory.sol
+++ b/contracts/factory/VaultFactory.sol
@@ -2,7 +2,9 @@
 pragma solidity 0.8.16;
 
 import '../library/UtilLib.sol';
+
 import '../VaultProxy.sol';
+import '../DVT/SSV/SSVVaultProxy.sol';
 import '../interfaces/IVaultFactory.sol';
 import '../interfaces/IStaderConfig.sol';
 
@@ -14,6 +16,8 @@ contract VaultFactory is IVaultFactory, AccessControlUpgradeable {
     address public vaultProxyImplementation;
 
     bytes32 public constant override NODE_REGISTRY_CONTRACT = keccak256('NODE_REGISTRY_CONTRACT');
+
+    address public ssvVaultProxyImplementation;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -45,6 +49,20 @@ contract VaultFactory is IVaultFactory, AccessControlUpgradeable {
         return withdrawVaultAddress;
     }
 
+    function deploySSVValidatorWithdrawalVault(uint8 _poolId, uint256 _validatorId)
+        external
+        override
+        onlyRole(NODE_REGISTRY_CONTRACT)
+        returns (address)
+    {
+        bytes32 salt = sha256(abi.encode(_poolId, _validatorId));
+        address withdrawVaultAddress = ClonesUpgradeable.cloneDeterministic(ssvVaultProxyImplementation, salt);
+        SSVVaultProxy(payable(withdrawVaultAddress)).initialise(_poolId, _validatorId, address(staderConfig));
+
+        emit SSVValidatorWithdrawalVaultCreated(_validatorId, withdrawVaultAddress);
+        return withdrawVaultAddress;
+    }
+
     function deployNodeELRewardVault(uint8 _poolId, uint256 _operatorId)
         external
         override
@@ -65,6 +83,16 @@ contract VaultFactory is IVaultFactory, AccessControlUpgradeable {
         uint256 _validatorCount
     ) external view override returns (address) {
         bytes32 salt = sha256(abi.encode(_poolId, _operatorId, _validatorCount));
+        return ClonesUpgradeable.predictDeterministicAddress(vaultProxyImplementation, salt);
+    }
+
+    function computeSSVValidatorWithdrawalVaultAddress(uint8 _poolId, uint256 _validatorId)
+        external
+        view
+        override
+        returns (address)
+    {
+        bytes32 salt = sha256(abi.encode(_poolId, _validatorId));
         return ClonesUpgradeable.predictDeterministicAddress(vaultProxyImplementation, salt);
     }
 
@@ -94,5 +122,15 @@ contract VaultFactory is IVaultFactory, AccessControlUpgradeable {
         UtilLib.checkNonZeroAddress(_vaultProxyImpl);
         vaultProxyImplementation = _vaultProxyImpl;
         emit UpdatedVaultProxyImplementation(vaultProxyImplementation);
+    }
+
+    function updateSSVVaultProxyImplementation(address _ssvVaultProxyImpl)
+        external
+        override
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        UtilLib.checkNonZeroAddress(_ssvVaultProxyImpl);
+        ssvVaultProxyImplementation = _ssvVaultProxyImpl;
+        emit UpdatedSSVVaultProxyImplementation(ssvVaultProxyImplementation);
     }
 }

--- a/contracts/interfaces/DVT/SSV/ISSVNodeRegistry.sol
+++ b/contracts/interfaces/DVT/SSV/ISSVNodeRegistry.sol
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.16;
+
+import '../../INodeRegistry.sol';
+
+import '../../../library/ValidatorStatus.sol';
+
+struct SSVOperator {
+    bool operatorType; // 0 for permissionless and 1 for permissioned
+    string operatorName; // name of the operator
+    address payable operatorRewardAddress; //Eth1 address of node for reward
+    address operatorAddress; // address of operator to interact with stader
+    uint64 operatorSSVID; // operator ID on SSV Network
+    uint64 keyShareCount; // count of key-share operator is running
+    uint256 bondAmount; // amount of ETH bond for new key shares
+}
+
+interface ISSVNodeRegistry {
+    error InvalidKeyCount();
+    error PageNumberIsZero();
+    error UNEXPECTED_STATUS();
+    error InvalidBondAmount();
+    error DifferentClusterSize();
+    error ValidatorNotWithdrawn();
+    error InvalidCollateralAmount();
+    error MisMatchingInputKeysSize();
+    error TooManyVerifiedKeysReported();
+    error InputSizeIsMoreThanBatchSize();
+    error TooManyWithdrawnKeysReported();
+    error CallerFailingSSVOperatorChecks();
+    error DuplicatePoolIDOrPoolNotAdded();
+    error OperatorNotOnboardOrPermissioned();
+    error OperatorAlreadyOnBoardedInProtocol();
+    error NotSufficientCollateralPerKeyShare();
+    error NotSufficientCollateralPerValidator();
+
+    event OperatorWhitelisted(address operator);
+    event UpdatedStaderConfig(address staderConfig);
+    event MarkedValidatorStatusAsPreDeposit(bytes pubkey);
+    event UpdatedInputKeyCountLimit(uint256 inputKeyCountLimit);
+    event ValidatorWithdrawn(bytes pubkey, uint256 validatorId);
+    event SSVOperatorOnboard(address operator, uint256 operatorId);
+    event UpdatedVerifiedKeyBatchSize(uint256 verifiedKeysBatchSize);
+    event BondDeposited(address operator, uint256 depositBondAmount);
+    event ValidatorMarkedAsFrontRunned(bytes pubkey, uint256 validatorId);
+    event UpdatedNextQueuedValidatorIndex(uint256 nextQueuedValidatorIndex);
+    event IncreasedTotalActiveValidatorCount(uint256 totalActiveValidatorCount);
+    event DecreasedTotalActiveValidatorCount(uint256 totalActiveValidatorCount);
+    event ValidatorStatusMarkedAsInvalidSignature(bytes pubkey, uint256 validatorId);
+    event AddedValidatorKey(address indexed nodeOperator, bytes pubkey, uint256 validatorId);
+    event UpdatedBatchSizeToRemoveValidatorFromSSV(uint64 batchSizeToRemoveValidatorFromSSV);
+    event UpdatedBatchSizeToRegisterValidatorWithSSV(uint64 batchSizeToRegisterValidatorFromSSV);
+
+    // function withdrawnValidators(bytes[] calldata _pubkeys) external;
+
+    function markValidatorReadyToDeposit(
+        bytes[] calldata _readyToDepositPubkey,
+        bytes[] calldata _frontRunPubkey,
+        bytes[] calldata _invalidSignaturePubkey
+    ) external;
+
+    // return validator struct for a validator Id
+    function validatorRegistry(uint256)
+        external
+        view
+        returns (
+            ValidatorStatus status,
+            bytes calldata pubkey,
+            bytes calldata preDepositSignature,
+            bytes calldata depositSignature,
+            address withdrawVaultAddress,
+            uint256 operatorId,
+            uint256 depositTime,
+            uint256 withdrawnTime
+        );
+
+    // returns the operator struct given operator Id
+    function operatorStructById(uint64)
+        external
+        view
+        returns (
+            bool operatorType,
+            string calldata operatorName,
+            address payable operatorRewardAddress,
+            address operatorAddress,
+            uint64 operatorSSVID,
+            uint64 keyShareCount,
+            uint256 bondAmount
+        );
+
+    function onlyPreDepositValidator(bytes calldata _pubkey) external view;
+
+    function increaseTotalActiveValidatorCount(uint256 _count) external;
+
+    function nextQueuedValidatorIndex() external view returns (uint256);
+
+    function updateNextQueuedValidatorIndex(uint256 _nextQueuedValidatorIndex) external;
+
+    function updateInputKeyCountLimit(uint16 _inputKeyCountLimit) external;
+
+    function updateBatchSizeToRemoveValidatorFromSSV(uint64 _batchSizeToRemoveValidatorFromSSV) external;
+
+    function updateBatchSizeToRegisterValidatorFromSSV(uint64 _batchSizeToRegisterValidatorFromSSV) external;
+
+    function markValidatorStatusAsPreDeposit(bytes calldata _pubkey) external;
+
+    function getAllActiveValidators(uint256 _pageNumber, uint256 _pageSize) external view returns (Validator[] memory);
+
+    // returns the total number of queued validators across all operators
+    function getTotalQueuedValidatorCount() external view returns (uint256);
+
+    // returns the total number of active validators across all operators
+    function getTotalActiveValidatorCount() external view returns (uint256);
+
+    function getCollateralETH() external view returns (uint256);
+
+    function getOperatorTotalKeys(uint256 _operatorId) external view returns (uint256 _totalKeys);
+
+    function operatorIDByAddress(address) external view returns (uint64);
+
+    // function getOperatorRewardAddress(uint256 _operatorId) external view returns (address payable);
+
+    function isExistingPubkey(bytes calldata _pubkey) external view returns (bool);
+
+    function isExistingOperator(address _operAddr) external view returns (bool);
+
+    function POOL_ID() external view returns (uint8);
+
+    function CLUSTER_SIZE() external view returns (uint8);
+
+    function inputKeyCountLimit() external view returns (uint16);
+
+    function nextOperatorId() external view returns (uint64);
+
+    function nextValidatorId() external view returns (uint256);
+
+    function verifiedKeyBatchSize() external view returns (uint256);
+
+    function totalActiveValidatorCount() external view returns (uint256);
+
+    function validatorIdByPubkey(bytes calldata _pubkey) external view returns (uint256);
+
+    function getOperatorsIdsForValidatorId(uint256 validatorId) external view returns (uint64[] memory);
+}

--- a/contracts/interfaces/DVT/SSV/ISSVPool.sol
+++ b/contracts/interfaces/DVT/SSV/ISSVPool.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.16;
+
+interface ISSVPool {
+    // Errors
+    error UnsupportedOperation();
+    error InvalidCommission();
+    error CouldNotDetermineExcessETH();
+
+    // Events
+    event ValidatorPreDepositedOnBeaconChain(bytes pubKey);
+    event ValidatorDepositedOnBeaconChain(uint256 indexed validatorId, bytes pubKey);
+    event UpdatedCommissionFees(uint256 protocolFee, uint256 operatorFee);
+    event ReceivedCollateralETH(uint256 amount);
+    event UpdatedStaderConfig(address staderConfig);
+    event ReceivedInsuranceFund(uint256 amount);
+    event TransferredETHToSSPMForDefectiveKeys(uint256 amount);
+
+    // Setters
+
+    function setCommissionFees(uint256 _protocolFee, uint256 _operatorFee) external; // sets the commission fees, protocol and operator
+
+    function receiveInsuranceFund() external payable;
+
+    function transferETHOfDefectiveKeysToSSPM(uint256 _defectiveKeyCount) external;
+
+    function fullDepositOnBeaconChain(bytes[] calldata _pubkey) external;
+
+    //Getters
+
+    function protocolFee() external view returns (uint256); // returns the protocol fee
+
+    function operatorFee() external view returns (uint256); // returns the operator fee
+
+    function stakeUserETHToBeaconChain() external payable;
+
+    function getSocializingPoolAddress() external view returns (address);
+
+    function getNodeRegistry() external view returns (address);
+}

--- a/contracts/interfaces/DVT/SSV/ISSVValidatorWithdrawalVault.sol
+++ b/contracts/interfaces/DVT/SSV/ISSVValidatorWithdrawalVault.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.16;
+
+import '../../IStaderConfig.sol';
+
+interface ISSVValidatorWithdrawalVault {
+    // Errors
+    error InvalidRewardAmount();
+    error NotEnoughRewardToDistribute();
+    error CallerNotNodeRegistryContract();
+
+    // Events
+    event ETHReceived(address indexed sender, uint256 amount);
+    event DistributeRewardFailed(uint256 rewardAmount, uint256 rewardThreshold);
+    event DistributedRewards(uint256 userShare, uint256 operatorShare, uint256 protocolShare);
+    event SettledFunds(uint256 userShare, uint256 operatorShare, uint256 protocolShare);
+    event UpdatedStaderConfig(address _staderConfig);
+
+    // methods
+    function distributeRewards() external;
+
+    function settleFunds() external;
+
+    // getters
+
+    function calculateValidatorWithdrawalShare(uint8 _poolId, IStaderConfig _staderConfig)
+        external
+        view
+        returns (
+            uint256 _userShare,
+            uint256 _operatorShare,
+            uint256 _protocolShare
+        );
+}

--- a/contracts/interfaces/DVT/SSV/ISSVVaultProxy.sol
+++ b/contracts/interfaces/DVT/SSV/ISSVVaultProxy.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.16;
+
+import '../../IStaderConfig.sol';
+
+interface ISSVVaultProxy {
+    error CallerNotOwner();
+    error AlreadyInitialized();
+    event UpdatedOwner(address owner);
+    event UpdatedStaderConfig(address staderConfig);
+
+    //Getters
+    function vaultSettleStatus() external view returns (bool);
+
+    function isInitialized() external view returns (bool);
+
+    function poolId() external view returns (uint8);
+
+    function validatorId() external view returns (uint256);
+
+    function owner() external view returns (address);
+
+    function staderConfig() external view returns (IStaderConfig);
+
+    //Setters
+    function updateOwner() external;
+
+    function updateStaderConfig(address _staderConfig) external;
+}

--- a/contracts/interfaces/IStaderConfig.sol
+++ b/contracts/interfaces/IStaderConfig.sol
@@ -58,6 +58,14 @@ interface IStaderConfig {
 
     function VALIDATOR_WITHDRAWAL_VAULT_IMPLEMENTATION() external view returns (bytes32);
 
+    function SSV_POOL() external view returns (bytes32);
+
+    function SSV_NODE_REGISTRY() external view returns (bytes32);
+
+    function SSV_SOCIALIZING_POOL() external view returns (bytes32);
+
+    function SSV_VALIDATOR_WITHDRAWAL_VAULT() external view returns (bytes32);
+
     //POR Feed Proxy
     function ETH_BALANCE_POR_FEED() external view returns (bytes32);
 
@@ -149,6 +157,14 @@ interface IStaderConfig {
     function getETHBalancePORFeedProxy() external view returns (address);
 
     function getETHXSupplyPORFeedProxy() external view returns (address);
+
+    function getSSVPool() external view returns (address);
+
+    function getSSVNodeRegistry() external view returns (address);
+
+    function getSSVSocializingPool() external view returns (address);
+
+    function getSSVValidatorWithdrawalVault() external view returns (address);
 
     // Tokens
     function getStaderToken() external view returns (address);

--- a/contracts/interfaces/IStaderInsuranceFund.sol
+++ b/contracts/interfaces/IStaderInsuranceFund.sol
@@ -6,6 +6,7 @@ interface IStaderInsuranceFund {
     error InvalidAmountProvided();
     error TransferFailed();
     error InSufficientBalance();
+    error InvalidPoolToReimburse();
 
     //Events
     event ReceivedInsuranceFund(uint256 amount);

--- a/contracts/interfaces/IVaultFactory.sol
+++ b/contracts/interfaces/IVaultFactory.sol
@@ -3,9 +3,11 @@ pragma solidity 0.8.16;
 
 interface IVaultFactory {
     event WithdrawVaultCreated(address withdrawVault);
+    event SSVValidatorWithdrawalVaultCreated(uint256 validatorId, address withdrawVaultAddress);
     event NodeELRewardVaultCreated(address nodeDistributor);
     event UpdatedStaderConfig(address staderConfig);
     event UpdatedVaultProxyImplementation(address vaultProxyImplementation);
+    event UpdatedSSVVaultProxyImplementation(address ssvVaultProxyImplementation);
 
     function NODE_REGISTRY_CONTRACT() external view returns (bytes32);
 
@@ -16,6 +18,8 @@ interface IVaultFactory {
         uint256 _validatorId
     ) external returns (address);
 
+    function deploySSVValidatorWithdrawalVault(uint8 _poolId, uint256 _validatorId) external returns (address);
+
     function deployNodeELRewardVault(uint8 _poolId, uint256 _operatorId) external returns (address);
 
     function computeWithdrawVaultAddress(
@@ -24,6 +28,11 @@ interface IVaultFactory {
         uint256 _validatorCount
     ) external view returns (address);
 
+    function computeSSVValidatorWithdrawalVaultAddress(uint8 _poolId, uint256 _validatorId)
+        external
+        view
+        returns (address);
+
     function computeNodeELRewardVaultAddress(uint8 _poolId, uint256 _operatorId) external view returns (address);
 
     function getValidatorWithdrawCredential(address _withdrawVault) external pure returns (bytes memory);
@@ -31,4 +40,6 @@ interface IVaultFactory {
     function updateStaderConfig(address _staderConfig) external;
 
     function updateVaultProxyAddress(address _vaultProxyImpl) external;
+
+    function updateSSVVaultProxyImplementation(address _ssvVaultProxyImpl) external;
 }

--- a/contracts/interfaces/SDCollateral/ISDCollateral.sol
+++ b/contracts/interfaces/SDCollateral/ISDCollateral.sol
@@ -17,6 +17,7 @@ interface ISDCollateral {
     error InvalidPoolLimit();
     error SDTransferFailed();
     error NoStateChange();
+    error CallerNotWithdrawVault();
 
     // events
     event UpdatedStaderConfig(address indexed staderConfig);
@@ -32,6 +33,12 @@ interface ISDCollateral {
     function withdraw(uint256 _requestedSD) external;
 
     function slashValidatorSD(uint256 _validatorId, uint8 _poolId) external;
+
+    function slashSSVOperatorSD(
+        uint8 _poolId,
+        uint256 _validatorId,
+        uint64[] memory operatorIds
+    ) external;
 
     function maxApproveSD() external;
 

--- a/contracts/interfaces/SSVNetwork/ISSVNetwork.sol
+++ b/contracts/interfaces/SSVNetwork/ISSVNetwork.sol
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.16;
+
+import './ISSVNetworkCore.sol';
+
+interface ISSVNetwork {
+    error ApprovalNotWithinTimeframe();
+    error CallerNotOwner();
+    error CallerNotWhitelisted();
+    error ClusterAlreadyEnabled();
+    error ClusterDoesNotExists();
+    error ClusterIsLiquidated();
+    error ClusterNotLiquidatable();
+    error ExceedValidatorLimit();
+    error FeeExceedsIncreaseLimit();
+    error FeeIncreaseNotAllowed();
+    error FeeTooLow();
+    error IncorrectClusterState();
+    error IncorrectValidatorState();
+    error InsufficientBalance();
+    error InvalidOperatorIdsLength();
+    error InvalidPublicKeyLength();
+    error MaxValueExceeded();
+    error NewBlockPeriodIsBelowMinimum();
+    error NoFeeDeclared();
+    error NotAuthorized();
+    error OperatorAlreadyExists();
+    error OperatorDoesNotExist();
+    error OperatorsListNotUnique();
+    error SameFeeChangeNotAllowed();
+    error TargetModuleDoesNotExist();
+    error TokenTransferFailed();
+    error UnsortedOperatorsList();
+    error ValidatorAlreadyExists();
+    error ValidatorDoesNotExist();
+    event AdminChanged(address previousAdmin, address newAdmin);
+    event BeaconUpgraded(address indexed beacon);
+    event ClusterDeposited(address indexed owner, uint64[] operatorIds, uint256 value, ISSVNetworkCore.Cluster cluster);
+    event ClusterLiquidated(address indexed owner, uint64[] operatorIds, ISSVNetworkCore.Cluster cluster);
+    event ClusterReactivated(address indexed owner, uint64[] operatorIds, ISSVNetworkCore.Cluster cluster);
+    event ClusterWithdrawn(address indexed owner, uint64[] operatorIds, uint256 value, ISSVNetworkCore.Cluster cluster);
+    event DeclareOperatorFeePeriodUpdated(uint64 value);
+    event ExecuteOperatorFeePeriodUpdated(uint64 value);
+    event FeeRecipientAddressUpdated(address indexed owner, address recipientAddress);
+    event Initialized(uint8 version);
+    event LiquidationThresholdPeriodUpdated(uint64 value);
+    event MinimumLiquidationCollateralUpdated(uint256 value);
+    event NetworkEarningsWithdrawn(uint256 value, address recipient);
+    event NetworkFeeUpdated(uint256 oldFee, uint256 newFee);
+    event OperatorAdded(uint64 indexed operatorId, address indexed owner, bytes publicKey, uint256 fee);
+    event OperatorFeeCancellationDeclared(address indexed owner, uint64 indexed operatorId);
+    event OperatorFeeDeclared(address indexed owner, uint64 indexed operatorId, uint256 blockNumber, uint256 fee);
+    event OperatorFeeExecuted(address indexed owner, uint64 indexed operatorId, uint256 blockNumber, uint256 fee);
+    event OperatorFeeIncreaseLimitUpdated(uint64 value);
+    event OperatorRemoved(uint64 indexed operatorId);
+    event OperatorWhitelistUpdated(uint64 indexed operatorId, address whitelisted);
+    event OperatorWithdrawn(address indexed owner, uint64 indexed operatorId, uint256 value);
+    event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event Upgraded(address indexed implementation);
+    event ValidatorAdded(
+        address indexed owner,
+        uint64[] operatorIds,
+        bytes publicKey,
+        bytes shares,
+        ISSVNetworkCore.Cluster cluster
+    );
+    event ValidatorRemoved(
+        address indexed owner,
+        uint64[] operatorIds,
+        bytes publicKey,
+        ISSVNetworkCore.Cluster cluster
+    );
+
+    fallback() external;
+
+    function acceptOwnership() external;
+
+    function cancelDeclaredOperatorFee(uint64 operatorId) external;
+
+    function declareOperatorFee(uint64 operatorId, uint256 fee) external;
+
+    function deposit(
+        address owner,
+        uint64[] memory operatorIds,
+        uint256 amount,
+        ISSVNetworkCore.Cluster memory cluster
+    ) external;
+
+    function executeOperatorFee(uint64 operatorId) external;
+
+    function getRegisterAuth(address userAddress) external view returns (bool authOperators, bool authValidators);
+
+    function initialize(
+        address token_,
+        address ssvOperators_,
+        address ssvClusters_,
+        address ssvDAO_,
+        address ssvViews_,
+        uint64 minimumBlocksBeforeLiquidation_,
+        uint256 minimumLiquidationCollateral_,
+        uint32 validatorsPerOperatorLimit_,
+        uint64 declareOperatorFeePeriod_,
+        uint64 executeOperatorFeePeriod_,
+        uint64 operatorMaxFeeIncrease_
+    ) external;
+
+    function liquidate(
+        address owner,
+        uint64[] memory operatorIds,
+        ISSVNetworkCore.Cluster memory cluster
+    ) external;
+
+    function owner() external view returns (address);
+
+    function pendingOwner() external view returns (address);
+
+    function proxiableUUID() external view returns (bytes32);
+
+    function reactivate(
+        uint64[] memory operatorIds,
+        uint256 amount,
+        ISSVNetworkCore.Cluster memory cluster
+    ) external;
+
+    function reduceOperatorFee(uint64 operatorId, uint256 fee) external;
+
+    function registerOperator(bytes memory publicKey, uint256 fee) external returns (uint64 id);
+
+    function registerValidator(
+        bytes memory publicKey,
+        uint64[] memory operatorIds,
+        bytes memory sharesData,
+        uint256 amount,
+        ISSVNetworkCore.Cluster memory cluster
+    ) external;
+
+    function removeOperator(uint64 operatorId) external;
+
+    function removeValidator(
+        bytes memory publicKey,
+        uint64[] memory operatorIds,
+        ISSVNetworkCore.Cluster memory cluster
+    ) external;
+
+    function renounceOwnership() external;
+
+    function setFeeRecipientAddress(address recipientAddress) external;
+
+    function setOperatorWhitelist(uint64 operatorId, address whitelisted) external;
+
+    function setRegisterAuth(
+        address userAddress,
+        bool authOperator,
+        bool authValidator
+    ) external;
+
+    function transferOwnership(address newOwner) external;
+
+    function updateDeclareOperatorFeePeriod(uint64 timeInSeconds) external;
+
+    function updateExecuteOperatorFeePeriod(uint64 timeInSeconds) external;
+
+    function updateLiquidationThresholdPeriod(uint64 blocks) external;
+
+    function updateMinimumLiquidationCollateral(uint256 amount) external;
+
+    function updateModule(uint8 moduleId, address moduleAddress) external;
+
+    function updateNetworkFee(uint256 fee) external;
+
+    function updateOperatorFeeIncreaseLimit(uint64 percentage) external;
+
+    function upgradeTo(address newImplementation) external;
+
+    function upgradeToAndCall(address newImplementation, bytes memory data) external payable;
+
+    function withdraw(
+        uint64[] memory operatorIds,
+        uint256 amount,
+        ISSVNetworkCore.Cluster memory cluster
+    ) external;
+
+    function withdrawNetworkEarnings(uint256 amount) external;
+
+    function withdrawOperatorEarnings(uint64 operatorId, uint256 amount) external;
+
+    function withdrawOperatorEarnings(uint64 operatorId) external;
+}

--- a/contracts/interfaces/SSVNetwork/ISSVNetworkCore.sol
+++ b/contracts/interfaces/SSVNetwork/ISSVNetworkCore.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.16;
+
+interface ISSVNetworkCore {
+    struct Cluster {
+        uint32 validatorCount;
+        uint64 networkFeeIndex;
+        uint64 index;
+        bool active;
+        uint256 balance;
+    }
+}

--- a/contracts/interfaces/SSVNetwork/ISSVNetworkViews.sol
+++ b/contracts/interfaces/SSVNetwork/ISSVNetworkViews.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.16;
+
+import './ISSVNetworkCore.sol';
+
+interface ISSVNetworkViews {
+    error ApprovalNotWithinTimeframe();
+    error CallerNotOwner();
+    error CallerNotWhitelisted();
+    error ClusterAlreadyEnabled();
+    error ClusterDoesNotExists();
+    error ClusterIsLiquidated();
+    error ClusterNotLiquidatable();
+    error ExceedValidatorLimit();
+    error FeeExceedsIncreaseLimit();
+    error FeeIncreaseNotAllowed();
+    error FeeTooLow();
+    error IncorrectClusterState();
+    error IncorrectValidatorState();
+    error InsufficientBalance();
+    error InvalidOperatorIdsLength();
+    error InvalidPublicKeyLength();
+    error MaxValueExceeded();
+    error NewBlockPeriodIsBelowMinimum();
+    error NoFeeDeclared();
+    error NotAuthorized();
+    error OperatorAlreadyExists();
+    error OperatorDoesNotExist();
+    error OperatorsListNotUnique();
+    error SameFeeChangeNotAllowed();
+    error TargetModuleDoesNotExist();
+    error TokenTransferFailed();
+    error UnsortedOperatorsList();
+    error ValidatorAlreadyExists();
+    error ValidatorDoesNotExist();
+    event AdminChanged(address previousAdmin, address newAdmin);
+    event BeaconUpgraded(address indexed beacon);
+    event Initialized(uint8 version);
+    event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event Upgraded(address indexed implementation);
+
+    function acceptOwnership() external;
+
+    function getBalance(
+        address owner,
+        uint64[] memory operatorIds,
+        ISSVNetworkCore.Cluster memory cluster
+    ) external view returns (uint256);
+
+    function getBurnRate(
+        address owner,
+        uint64[] memory operatorIds,
+        ISSVNetworkCore.Cluster memory cluster
+    ) external view returns (uint256);
+
+    function getLiquidationThresholdPeriod() external view returns (uint64);
+
+    function getMinimumLiquidationCollateral() external view returns (uint256);
+
+    function getNetworkEarnings() external view returns (uint256);
+
+    function getNetworkFee() external view returns (uint256);
+
+    function getOperatorById(uint64 operatorId)
+        external
+        view
+        returns (
+            address,
+            uint256,
+            uint32,
+            address,
+            bool,
+            bool
+        );
+
+    function getOperatorDeclaredFee(uint64 operatorId)
+        external
+        view
+        returns (
+            uint256,
+            uint64,
+            uint64
+        );
+
+    function getOperatorEarnings(uint64 id) external view returns (uint256);
+
+    function getOperatorFee(uint64 operatorId) external view returns (uint256);
+
+    function getOperatorFeeIncreaseLimit() external view returns (uint64 operatorMaxFeeIncrease);
+
+    function getOperatorFeePeriods()
+        external
+        view
+        returns (uint64 declareOperatorFeePeriod, uint64 executeOperatorFeePeriod);
+
+    function getValidator(address owner, bytes memory publicKey) external view returns (bool active);
+
+    function getValidatorsPerOperatorLimit() external view returns (uint32);
+
+    function getVersion() external view returns (string memory version);
+
+    function initialize(address ssvNetwork_) external;
+
+    function isLiquidatable(
+        address owner,
+        uint64[] memory operatorIds,
+        ISSVNetworkCore.Cluster memory cluster
+    ) external view returns (bool);
+
+    function isLiquidated(
+        address owner,
+        uint64[] memory operatorIds,
+        ISSVNetworkCore.Cluster memory cluster
+    ) external view returns (bool);
+
+    function owner() external view returns (address);
+
+    function pendingOwner() external view returns (address);
+
+    function proxiableUUID() external view returns (bytes32);
+
+    function renounceOwnership() external;
+
+    function ssvNetwork() external view returns (address);
+
+    function transferOwnership(address newOwner) external;
+
+    function upgradeTo(address newImplementation) external;
+
+    function upgradeToAndCall(address newImplementation, bytes memory data) external payable;
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -23,6 +23,15 @@ const config: HardhatUserConfig = {
           },
         },
       },
+      {
+        version: '0.8.18',
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      }
     ],
   },
   defaultNetwork: 'mainnet',


### PR DESCRIPTION
Adding new SSV Pool under DVT section, following are the big changes

- SSV Node Registry contract similar to the existing pool having functionality of registering and removing validator with SSV Network
- SSV Pool contract to make beacon chain deposit work like permissioned Pool 
- New vault proxy - SSVVaultProxy, as we don't need all the inputs of current vaultProxy
- New vaultImplementation - different calculation for reward and settlement as now 4 operators per validator
- Changes in SDCollateral to slash SD 
- Changes in insurance fund to reimburse user 1 ETH in case of front running or invalid signature
- Changes in StaderConfig to add SSV related contracts 
