### PR TITLE
claiming SD reward along with  depositing as collateral

### DIFF
--- a/contracts/SDCollateral.sol
+++ b/contracts/SDCollateral.sol
@@ -51,6 +51,21 @@ contract SDCollateral is ISDCollateral, AccessControlUpgradeable, ReentrancyGuar
         emit SDDeposited(operator, _sdAmount);
     }
 
+    /**
+     * @dev sender should approve this contract for spending SD
+     * @dev allows sender to deposit SD collateral on behalf of a operator
+     * @param _sdAmount SD Token Amount to Deposit
+     * @param _operator operator address
+     */
+    function depositSDAsCollateralFor(address _operator, uint256 _sdAmount) external override {
+        if (!IERC20(staderConfig.getStaderToken()).transferFrom(msg.sender, address(this), _sdAmount)) {
+            revert SDTransferFailed();
+        }
+        operatorSDBalance[_operator] += _sdAmount;
+
+        emit SDDeposited(_operator, _sdAmount);
+    }
+
     /// @notice for operator to withdraw their sd collateral, which is over and above withdraw threshold
     function withdraw(uint256 _requestedSD) external override {
         address operator = msg.sender;

--- a/contracts/SocializingPool.sol
+++ b/contracts/SocializingPool.sol
@@ -5,6 +5,7 @@ pragma solidity 0.8.16;
 import './library/UtilLib.sol';
 
 import './interfaces/ISocializingPool.sol';
+import './interfaces/SDCollateral/ISDCollateral.sol';
 import './interfaces/IStaderStakePoolManager.sol';
 import './interfaces/IPermissionlessNodeRegistry.sol';
 
@@ -108,11 +109,27 @@ contract SocializingPool is
         uint256[] calldata _amountSD,
         uint256[] calldata _amountETH,
         bytes32[][] calldata _merkleProof
-    ) external override nonReentrant whenNotPaused {
-        address operator = msg.sender;
-        (uint256 totalAmountSD, uint256 totalAmountETH) = _claim(_index, operator, _amountSD, _amountETH, _merkleProof);
+    ) external override whenNotPaused {
+        claimAndDepositSDAsCollateral(0, _index, _amountSD, _amountETH, _merkleProof);
+    }
 
-        address operatorRewardsAddr = UtilLib.getOperatorRewardAddress(operator, staderConfig);
+    ///@notice claim rewards along with depositing a given amount of SD Token as collateral
+    function claimAndDepositSDAsCollateral(
+        uint256 _amountOfSDToDeposit,
+        uint256[] calldata _index,
+        uint256[] calldata _amountSD,
+        uint256[] calldata _amountETH,
+        bytes32[][] calldata _merkleProof
+    ) public override nonReentrant whenNotPaused {
+        (uint256 totalAmountSD, uint256 totalAmountETH) = _claim(
+            _index,
+            msg.sender,
+            _amountSD,
+            _amountETH,
+            _merkleProof
+        );
+
+        address operatorRewardsAddr = UtilLib.getOperatorRewardAddress(msg.sender, staderConfig);
 
         bool success;
         if (totalAmountETH > 0) {
@@ -123,11 +140,23 @@ contract SocializingPool is
             }
         }
 
-        if (totalAmountSD > 0) {
-            totalOperatorSDRewardsRemaining -= totalAmountSD;
-            if (!IERC20(staderConfig.getStaderToken()).transfer(operatorRewardsAddr, totalAmountSD)) {
+        if (_amountOfSDToDeposit > totalAmountSD) {
+            revert InvalidSDDepositAmount();
+        }
+        totalOperatorSDRewardsRemaining -= totalAmountSD;
+        if ((totalAmountSD - _amountOfSDToDeposit) > 0) {
+            if (
+                !IERC20(staderConfig.getStaderToken()).transfer(
+                    operatorRewardsAddr,
+                    (totalAmountSD - _amountOfSDToDeposit)
+                )
+            ) {
                 revert SDTransferFailed();
             }
+        }
+
+        if (_amountOfSDToDeposit > 0) {
+            ISDCollateral(staderConfig.getSDCollateral()).depositSDAsCollateralFor(msg.sender, _amountOfSDToDeposit);
         }
 
         emit OperatorRewardsClaimed(operatorRewardsAddr, totalAmountETH, totalAmountSD);
@@ -157,6 +186,14 @@ contract SocializingPool is
                 revert InvalidProof(_index[i], _operator);
             }
         }
+    }
+
+    /// @notice for max approval to SDCollateral contract for spending SD tokens
+    function maxApproveSDToSDCollateral() external override {
+        UtilLib.onlyManagerRole(msg.sender, staderConfig);
+        address sdCollateral = staderConfig.getSDCollateral();
+        UtilLib.checkNonZeroAddress(sdCollateral);
+        IERC20(staderConfig.getStaderToken()).approve(sdCollateral, type(uint256).max);
     }
 
     function verifyProof(

--- a/contracts/interfaces/ISocializingPool.sol
+++ b/contracts/interfaces/ISocializingPool.sol
@@ -37,6 +37,7 @@ interface ISocializingPool {
     error InvalidProof(uint256 cycle, address operator);
     error InvalidCycleIndex();
     error FutureCycleIndex();
+    error InvalidSDDepositAmount();
 
     // events
     event UpdatedStaderConfig(address indexed staderConfig);
@@ -57,7 +58,17 @@ interface ISocializingPool {
     // methods
     function handleRewards(RewardsData calldata _rewardsData) external;
 
+    function maxApproveSDToSDCollateral() external;
+
     function claim(
+        uint256[] calldata _index,
+        uint256[] calldata _amountSD,
+        uint256[] calldata _amountETH,
+        bytes32[][] calldata _merkleProof
+    ) external;
+
+    function claimAndDepositSDAsCollateral(
+        uint256 _amountOfSDToDeposit,
         uint256[] calldata _index,
         uint256[] calldata _amountSD,
         uint256[] calldata _amountETH,

--- a/contracts/interfaces/SDCollateral/ISDCollateral.sol
+++ b/contracts/interfaces/SDCollateral/ISDCollateral.sol
@@ -29,6 +29,8 @@ interface ISDCollateral {
     // methods
     function depositSDAsCollateral(uint256 _sdAmount) external;
 
+    function depositSDAsCollateralFor(address _operator, uint256 _sdAmount) external;
+
     function withdraw(uint256 _requestedSD) external;
 
     function slashValidatorSD(uint256 _validatorId, uint8 _poolId) external;


### PR DESCRIPTION
Below are the changes across SDCollateral.sol and SocializingPool.sol

1. Function to deposit SD as collateral on behalf of an operator by the sender
2. Function to claim SocializingPool reward along with depositing a certain amount of SD as collateral to SDCollateral contract
3. Function to approve max allowance to SDCollateral contract by Socializing Pool controlled by MANAGER
4. updated test cases for both Socializing Pool and SDCollateral in StaderOracle.t.sol file 