### PR TITLE
238: fixing lint issues with imports

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -3,6 +3,14 @@
   "plugins": [],
   "rules": {
     "avoid-suicide": "error",
-    "avoid-sha3": "warn"
+    "avoid-sha3": "warn",
+    "var-name-mixedcase": "off",
+    "func-name-mixedcase": "off",
+    "func-visibility": [
+      "warn",
+      {
+        "ignoreConstructors": true
+      }
+    ]
   }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -66,7 +66,7 @@
         {
             "label": "test",
             "type": "shell",
-            "command": "forge test -vvv",
+            "command": "forge test -v",
             "options": {
                 "cwd": "${workspaceFolder}"
             },

--- a/contracts/Auction.sol
+++ b/contracts/Auction.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "./library/UtilLib.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 
-import "../contracts/interfaces/SDCollateral/IAuction.sol";
-import "../contracts/interfaces/IStaderStakePoolManager.sol";
-
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import { UtilLib } from "./library/UtilLib.sol";
+import { IAuction } from "../contracts/interfaces/SDCollateral/IAuction.sol";
+import { IStaderStakePoolManager } from "../contracts/interfaces/IStaderStakePoolManager.sol";
+import { IStaderConfig } from "./interfaces/IStaderConfig.sol";
 
 contract Auction is IAuction, AccessControlUpgradeable, ReentrancyGuardUpgradeable {
     IStaderConfig public override staderConfig;

--- a/contracts/ETHx.sol
+++ b/contracts/ETHx.sol
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
-import "./library/UtilLib.sol";
 
-import "./interfaces/IStaderConfig.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 
-import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import { UtilLib } from "./library/UtilLib.sol";
+
+import { IStaderConfig } from "./interfaces/IStaderConfig.sol";
 
 /**
  * @title ETHx token Contract

--- a/contracts/L2/ETHx.sol
+++ b/contracts/L2/ETHx.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 
 /**
  * @title ETHx token Contract for L2s

--- a/contracts/NodeELRewardVault.sol
+++ b/contracts/NodeELRewardVault.sol
@@ -1,18 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "./library/UtilLib.sol";
+import { UtilLib } from "./library/UtilLib.sol";
 
-import "./interfaces/IPoolUtils.sol";
-import "./interfaces/IVaultProxy.sol";
-import "./interfaces/INodeRegistry.sol";
-import "./interfaces/INodeELRewardVault.sol";
-import "./interfaces/IStaderStakePoolManager.sol";
-import "./interfaces/IOperatorRewardsCollector.sol";
+import { IStaderConfig } from "./interfaces/IStaderConfig.sol";
+import { IPoolUtils } from "./interfaces/IPoolUtils.sol";
+import { IVaultProxy } from "./interfaces/IVaultProxy.sol";
+import { INodeELRewardVault } from "./interfaces/INodeELRewardVault.sol";
+import { IStaderStakePoolManager } from "./interfaces/IStaderStakePoolManager.sol";
+import { IOperatorRewardsCollector } from "./interfaces/IOperatorRewardsCollector.sol";
 
 contract NodeELRewardVault is INodeELRewardVault {
-    constructor() {}
-
     /**
      * @notice Allows the contract to receive ETH
      * @dev execution layer rewards may be sent as plain ETH transfers

--- a/contracts/OperatorRewardsCollector.sol
+++ b/contracts/OperatorRewardsCollector.sol
@@ -1,20 +1,21 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "./library/UtilLib.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 
-import "./interfaces/INodeRegistry.sol";
-import "./interfaces/INodeELRewardVault.sol";
-import "./interfaces/IPermissionlessNodeRegistry.sol";
-import "./interfaces/IOperatorRewardsCollector.sol";
-import "./interfaces/IStaderConfig.sol";
-import "./interfaces/ISDUtilityPool.sol";
-import "./interfaces/SDCollateral/ISDCollateral.sol";
-import "./interfaces/IWETH.sol";
-import "../contracts/interfaces/IStaderOracle.sol";
+import { UtilLib } from "./library/UtilLib.sol";
 
-import "@openzeppelin/contracts/utils/math/Math.sol";
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { IStaderConfig } from "./interfaces/IStaderConfig.sol";
+import { INodeRegistry } from "./interfaces/INodeRegistry.sol";
+import { INodeELRewardVault } from "./interfaces/INodeELRewardVault.sol";
+import { IPermissionlessNodeRegistry } from "./interfaces/IPermissionlessNodeRegistry.sol";
+import { IOperatorRewardsCollector } from "./interfaces/IOperatorRewardsCollector.sol";
+import { IStaderConfig } from "./interfaces/IStaderConfig.sol";
+import { ISDUtilityPool, UserData, OperatorLiquidation } from "./interfaces/ISDUtilityPool.sol";
+import { ISDCollateral } from "./interfaces/SDCollateral/ISDCollateral.sol";
+import { IWETH } from "./interfaces/IWETH.sol";
+import { IStaderOracle } from "../contracts/interfaces/IStaderOracle.sol";
 
 contract OperatorRewardsCollector is IOperatorRewardsCollector, AccessControlUpgradeable {
     IStaderConfig public staderConfig;
@@ -46,22 +47,15 @@ contract OperatorRewardsCollector is IOperatorRewardsCollector, AccessControlUpg
         emit DepositedFor(msg.sender, _receiver, msg.value);
     }
 
-    event log_uint256(string message, uint256 value);
-
     /**
      * @notice Claims payouts for an operator, repaying any outstanding liquidations and transferring any remaining balance to the operator's rewards address.
      * @dev This function first checks for any unpaid liquidations for the operator and repays them if necessary. Then, it transfers any remaining balance to the operator's reward address.
      */
     function claim() external {
         claimLiquidation(msg.sender);
-
-        emit log_uint256("withdrawableInEth(msg.sender)", withdrawableInEth(msg.sender));
-
         uint256 amount = balances[msg.sender] > withdrawableInEth(msg.sender)
             ? withdrawableInEth(msg.sender)
             : balances[msg.sender];
-
-        emit log_uint256("claim amount", amount);
         _claim(msg.sender, amount);
     }
 

--- a/contracts/Penalty.sol
+++ b/contracts/Penalty.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "./library/UtilLib.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 
-import "./interfaces/IPenalty.sol";
-import "./interfaces/IRatedV1.sol";
-import "./interfaces/IStaderOracle.sol";
-import "./interfaces/IStaderConfig.sol";
+import { UtilLib } from "./library/UtilLib.sol";
 
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import { IPenalty } from "./interfaces/IPenalty.sol";
+import { IStaderOracle } from "./interfaces/IStaderOracle.sol";
+import { IStaderConfig } from "./interfaces/IStaderConfig.sol";
+import { IRatedV1 } from "./interfaces/IRatedV1.sol";
 
 contract Penalty is IPenalty, AccessControlUpgradeable, ReentrancyGuardUpgradeable {
     IStaderConfig public staderConfig;

--- a/contracts/PermissionedNodeRegistry.sol
+++ b/contracts/PermissionedNodeRegistry.sol
@@ -1,22 +1,22 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "./library/UtilLib.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 
-import "./library/ValidatorStatus.sol";
-import "./interfaces/IStaderConfig.sol";
-import "./interfaces/IVaultFactory.sol";
-import "./interfaces/IPoolUtils.sol";
-import "./interfaces/INodeRegistry.sol";
-import "./interfaces/IPermissionedPool.sol";
-import "./interfaces/IValidatorWithdrawalVault.sol";
-import "./interfaces/SDCollateral/ISDCollateral.sol";
-import "./interfaces/IPermissionedNodeRegistry.sol";
+import { UtilLib } from "./library/UtilLib.sol";
 
-import "@openzeppelin/contracts/utils/math/Math.sol";
-import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import { ValidatorStatus } from "./library/ValidatorStatus.sol";
+import { IStaderConfig } from "./interfaces/IStaderConfig.sol";
+import { IVaultFactory } from "./interfaces/IVaultFactory.sol";
+import { IPoolUtils } from "./interfaces/IPoolUtils.sol";
+import { Operator, Validator, INodeRegistry } from "./interfaces/INodeRegistry.sol";
+import { IPermissionedPool } from "./interfaces/IPermissionedPool.sol";
+import { IValidatorWithdrawalVault } from "./interfaces/IValidatorWithdrawalVault.sol";
+import { ISDCollateral } from "./interfaces/SDCollateral/ISDCollateral.sol";
+import { IPermissionedNodeRegistry } from "./interfaces/IPermissionedNodeRegistry.sol";
 
 contract PermissionedNodeRegistry is
     INodeRegistry,

--- a/contracts/PermissionedPool.sol
+++ b/contracts/PermissionedPool.sol
@@ -1,22 +1,20 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "./library/UtilLib.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 
-import "./library/ValidatorStatus.sol";
+import { UtilLib } from "./library/UtilLib.sol";
 
-import "./interfaces/IStaderConfig.sol";
-import "./interfaces/IVaultFactory.sol";
-import "./interfaces/INodeRegistry.sol";
-import "./interfaces/IStaderPoolBase.sol";
-import "./interfaces/IDepositContract.sol";
-import "./interfaces/IStaderInsuranceFund.sol";
-import "./interfaces/IStaderStakePoolManager.sol";
-import "./interfaces/IPermissionedNodeRegistry.sol";
-
-import "@openzeppelin/contracts/utils/math/Math.sol";
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import { IStaderConfig } from "./interfaces/IStaderConfig.sol";
+import { IVaultFactory } from "./interfaces/IVaultFactory.sol";
+import { INodeRegistry } from "./interfaces/INodeRegistry.sol";
+import { IStaderPoolBase } from "./interfaces/IStaderPoolBase.sol";
+import { IDepositContract } from "./interfaces/IDepositContract.sol";
+import { IStaderInsuranceFund } from "./interfaces/IStaderInsuranceFund.sol";
+import { IStaderStakePoolManager } from "./interfaces/IStaderStakePoolManager.sol";
+import { IPermissionedNodeRegistry } from "./interfaces/IPermissionedNodeRegistry.sol";
 
 contract PermissionedPool is IStaderPoolBase, AccessControlUpgradeable, ReentrancyGuardUpgradeable {
     using Math for uint256;

--- a/contracts/PermissionlessNodeRegistry.sol
+++ b/contracts/PermissionlessNodeRegistry.sol
@@ -1,25 +1,25 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "./library/UtilLib.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 
-import "./library/ValidatorStatus.sol";
-import "./interfaces/IStaderConfig.sol";
-import "./interfaces/IVaultFactory.sol";
-import "./interfaces/IPoolUtils.sol";
-import "./interfaces/INodeRegistry.sol";
-import "./interfaces/ISDUtilityPool.sol";
-import "./interfaces/IPermissionlessPool.sol";
-import "./interfaces/INodeELRewardVault.sol";
-import "./interfaces/IStaderInsuranceFund.sol";
-import "./interfaces/IValidatorWithdrawalVault.sol";
-import "./interfaces/SDCollateral/ISDCollateral.sol";
-import "./interfaces/IPermissionlessNodeRegistry.sol";
-import "./interfaces/IOperatorRewardsCollector.sol";
+import { UtilLib } from "./library/UtilLib.sol";
 
-import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import { ValidatorStatus } from "./library/ValidatorStatus.sol";
+import { IStaderConfig } from "./interfaces/IStaderConfig.sol";
+import { IVaultFactory } from "./interfaces/IVaultFactory.sol";
+import { IPoolUtils } from "./interfaces/IPoolUtils.sol";
+import { Operator, Validator, INodeRegistry } from "./interfaces/INodeRegistry.sol";
+import { ISDUtilityPool } from "./interfaces/ISDUtilityPool.sol";
+import { IPermissionlessPool } from "./interfaces/IPermissionlessPool.sol";
+import { INodeELRewardVault } from "./interfaces/INodeELRewardVault.sol";
+import { IStaderInsuranceFund } from "./interfaces/IStaderInsuranceFund.sol";
+import { IValidatorWithdrawalVault } from "./interfaces/IValidatorWithdrawalVault.sol";
+import { ISDCollateral } from "./interfaces/SDCollateral/ISDCollateral.sol";
+import { IPermissionlessNodeRegistry } from "./interfaces/IPermissionlessNodeRegistry.sol";
+import { IOperatorRewardsCollector } from "./interfaces/IOperatorRewardsCollector.sol";
 
 contract PermissionlessNodeRegistry is
     INodeRegistry,

--- a/contracts/PermissionlessPool.sol
+++ b/contracts/PermissionlessPool.sol
@@ -1,20 +1,18 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "./library/UtilLib.sol";
-import "./library/ValidatorStatus.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 
-import "./interfaces/IStaderConfig.sol";
-import "./interfaces/IVaultFactory.sol";
-import "./interfaces/INodeRegistry.sol";
-import "./interfaces/IStaderPoolBase.sol";
-import "./interfaces/IDepositContract.sol";
-import "./interfaces/IStaderStakePoolManager.sol";
-import "./interfaces/IPermissionlessNodeRegistry.sol";
+import { UtilLib } from "./library/UtilLib.sol";
 
-import "@openzeppelin/contracts/utils/math/Math.sol";
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import { IStaderConfig } from "./interfaces/IStaderConfig.sol";
+import { IVaultFactory } from "./interfaces/IVaultFactory.sol";
+import { INodeRegistry } from "./interfaces/INodeRegistry.sol";
+import { IStaderPoolBase } from "./interfaces/IStaderPoolBase.sol";
+import { IDepositContract } from "./interfaces/IDepositContract.sol";
+import { IPermissionlessNodeRegistry } from "./interfaces/IPermissionlessNodeRegistry.sol";
 
 contract PermissionlessPool is IStaderPoolBase, AccessControlUpgradeable, ReentrancyGuardUpgradeable {
     using Math for uint256;

--- a/contracts/PoolSelector.sol
+++ b/contracts/PoolSelector.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "./library/UtilLib.sol";
+import { UtilLib } from "./library/UtilLib.sol";
 
-import "./interfaces/IStaderConfig.sol";
-import "./interfaces/IPoolSelector.sol";
-import "./interfaces/IPoolUtils.sol";
+import { IStaderConfig } from "./interfaces/IStaderConfig.sol";
+import { IPoolSelector } from "./interfaces/IPoolSelector.sol";
+import { IPoolUtils } from "./interfaces/IPoolUtils.sol";
 
-import "@openzeppelin/contracts/utils/math/Math.sol";
-import "@openzeppelin/contracts/utils/math/SafeMath.sol";
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { SafeMath } from "@openzeppelin/contracts/utils/math/SafeMath.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 
 contract PoolSelector is IPoolSelector, AccessControlUpgradeable {
     using Math for uint256;

--- a/contracts/PoolUtils.sol
+++ b/contracts/PoolUtils.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "./library/UtilLib.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 
-import "./interfaces/IPoolUtils.sol";
-import "./interfaces/IStaderPoolBase.sol";
-import "./interfaces/IStaderConfig.sol";
+import { UtilLib } from "./library/UtilLib.sol";
 
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { IPoolUtils } from "./interfaces/IPoolUtils.sol";
+import { IStaderPoolBase } from "./interfaces/IStaderPoolBase.sol";
+import { INodeRegistry } from "./interfaces/INodeRegistry.sol";
+import { IStaderConfig } from "./interfaces/IStaderConfig.sol";
 
 contract PoolUtils is IPoolUtils, AccessControlUpgradeable {
     uint64 private constant PUBKEY_LENGTH = 48;

--- a/contracts/ProxyAdmin.sol
+++ b/contracts/ProxyAdmin.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import { ProxyAdmin } from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 // Need to import ProxyAdmin within contracts folder so `hardhat compile` can find it and compile it
 // The artifact of ProxyAdmin needs to be built so as to be used within scripts/safe-scripts

--- a/contracts/SDCollateral.sol
+++ b/contracts/SDCollateral.sol
@@ -1,18 +1,20 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "./library/UtilLib.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-import "../contracts/interfaces/IPoolUtils.sol";
-import "../contracts/interfaces/SDCollateral/ISDCollateral.sol";
-import "../contracts/interfaces/SDCollateral/IAuction.sol";
-import "../contracts/interfaces/IStaderOracle.sol";
-import "./interfaces/ISDUtilityPool.sol";
+import { UtilLib } from "./library/UtilLib.sol";
 
-import "@openzeppelin/contracts/utils/math/Math.sol";
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IStaderConfig } from "./interfaces/IStaderConfig.sol";
+import { INodeRegistry } from "./interfaces/INodeRegistry.sol";
+import { IPoolUtils } from "../contracts/interfaces/IPoolUtils.sol";
+import { ISDCollateral } from "../contracts/interfaces/SDCollateral/ISDCollateral.sol";
+import { IAuction } from "../contracts/interfaces/SDCollateral/IAuction.sol";
+import { IStaderOracle } from "../contracts/interfaces/IStaderOracle.sol";
+import { ISDUtilityPool } from "./interfaces/ISDUtilityPool.sol";
 
 contract SDCollateral is ISDCollateral, AccessControlUpgradeable, ReentrancyGuardUpgradeable {
     IStaderConfig public override staderConfig;

--- a/contracts/SDIncentiveController.sol
+++ b/contracts/SDIncentiveController.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-import "./library/UtilLib.sol";
-import "./interfaces/IStaderConfig.sol";
-import "./interfaces/ISDUtilityPool.sol";
-import "./interfaces/ISDIncentiveController.sol";
+import { UtilLib } from "./library/UtilLib.sol";
+import { IStaderConfig } from "./interfaces/IStaderConfig.sol";
+import { ISDUtilityPool } from "./interfaces/ISDUtilityPool.sol";
+import { ISDIncentiveController } from "./interfaces/ISDIncentiveController.sol";
 
 /// @title SDIncentiveController
 /// @notice This contract handles the distribution of reward tokens for the utility pool.

--- a/contracts/SDUtilityPool.sol
+++ b/contracts/SDUtilityPool.sol
@@ -1,18 +1,19 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "./library/UtilLib.sol";
-import "./interfaces/IStaderConfig.sol";
-import "./interfaces/ISDIncentiveController.sol";
-import "./interfaces/ISDUtilityPool.sol";
-import "./interfaces/SDCollateral/ISDCollateral.sol";
-import "./interfaces/IPoolUtils.sol";
-import "./interfaces/IOperatorRewardsCollector.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 
-import "@openzeppelin/contracts/utils/math/Math.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { UtilLib } from "./library/UtilLib.sol";
+
+import { IStaderConfig } from "./interfaces/IStaderConfig.sol";
+import { ISDIncentiveController } from "./interfaces/ISDIncentiveController.sol";
+import { ISDUtilityPool, OperatorLiquidation, UserData } from "./interfaces/ISDUtilityPool.sol";
+import { ISDCollateral } from "./interfaces/SDCollateral/ISDCollateral.sol";
+import { IPoolUtils } from "./interfaces/IPoolUtils.sol";
+import { IOperatorRewardsCollector } from "./interfaces/IOperatorRewardsCollector.sol";
 
 contract SDUtilityPool is ISDUtilityPool, AccessControlUpgradeable, PausableUpgradeable {
     using Math for uint256;

--- a/contracts/SocializingPool.sol
+++ b/contracts/SocializingPool.sol
@@ -1,19 +1,18 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
 pragma solidity 0.8.16;
 
-import "./library/UtilLib.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import { MerkleProofUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/cryptography/MerkleProofUpgradeable.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-import "./interfaces/ISocializingPool.sol";
-import "./interfaces/SDCollateral/ISDCollateral.sol";
-import "./interfaces/IStaderStakePoolManager.sol";
-import "./interfaces/IPermissionlessNodeRegistry.sol";
+import { UtilLib } from "./library/UtilLib.sol";
 
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/utils/cryptography/MerkleProofUpgradeable.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IStaderConfig } from "./interfaces/IStaderConfig.sol";
+import { ISocializingPool, RewardsData } from "./interfaces/ISocializingPool.sol";
+import { ISDCollateral } from "./interfaces/SDCollateral/ISDCollateral.sol";
+import { IStaderStakePoolManager } from "./interfaces/IStaderStakePoolManager.sol";
 
 contract SocializingPool is
     ISocializingPool,

--- a/contracts/StaderConfig.sol
+++ b/contracts/StaderConfig.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "./library/UtilLib.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 
-import "./interfaces/IStaderConfig.sol";
+import { UtilLib } from "./library/UtilLib.sol";
 
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { IStaderConfig } from "./interfaces/IStaderConfig.sol";
 
 contract StaderConfig is IStaderConfig, AccessControlUpgradeable {
     // staked ETH per node on beacon chain i.e. 32 ETH

--- a/contracts/StaderInsuranceFund.sol
+++ b/contracts/StaderInsuranceFund.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "./library/UtilLib.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 
-import "./interfaces/IStaderConfig.sol";
-import "./interfaces/IPermissionedPool.sol";
-import "./interfaces/IStaderInsuranceFund.sol";
+import { UtilLib } from "./library/UtilLib.sol";
 
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import { IStaderConfig } from "./interfaces/IStaderConfig.sol";
+import { IPermissionedPool } from "./interfaces/IPermissionedPool.sol";
+import { IStaderInsuranceFund } from "./interfaces/IStaderInsuranceFund.sol";
 
 contract StaderInsuranceFund is IStaderInsuranceFund, AccessControlUpgradeable, ReentrancyGuardUpgradeable {
     IStaderConfig public staderConfig;

--- a/contracts/StaderOracle.sol
+++ b/contracts/StaderOracle.sol
@@ -1,18 +1,21 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "./library/UtilLib.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 
-import "./interfaces/IPoolUtils.sol";
-import "./interfaces/IStaderOracle.sol";
-import "./interfaces/ISocializingPool.sol";
-import "./interfaces/INodeRegistry.sol";
-import "./interfaces/IStaderStakePoolManager.sol";
+import { AggregatorV3Interface } from "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
 
-import "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
-import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import { UtilLib } from "./library/UtilLib.sol";
+
+import { IStaderConfig } from "./interfaces/IStaderConfig.sol";
+import { IPoolUtils } from "./interfaces/IPoolUtils.sol";
+import { IStaderOracle } from "./interfaces/IStaderOracle.sol";
+import { ISocializingPool } from "./interfaces/ISocializingPool.sol";
+import { INodeRegistry } from "./interfaces/INodeRegistry.sol";
+import { ExchangeRate, MissedAttestationPenaltyData, SDPriceData, ValidatorStats, ValidatorVerificationDetail, WithdrawnValidators } from "./interfaces/IStaderOracle.sol";
+import { RewardsData } from "./interfaces/ISocializingPool.sol";
 
 contract StaderOracle is IStaderOracle, AccessControlUpgradeable, PausableUpgradeable, ReentrancyGuardUpgradeable {
     bool public override erInspectionMode;

--- a/contracts/StaderStakePoolsManager.sol
+++ b/contracts/StaderStakePoolsManager.sol
@@ -1,23 +1,22 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
 pragma solidity 0.8.16;
 
-import "./library/UtilLib.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { SafeMath } from "@openzeppelin/contracts/utils/math/SafeMath.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 
-import "./ETHx.sol";
-import "./interfaces/IPoolUtils.sol";
-import "./interfaces/IPoolSelector.sol";
-import "./interfaces/IStaderConfig.sol";
-import "./interfaces/IStaderOracle.sol";
-import "./interfaces/IStaderPoolBase.sol";
-import "./interfaces/IUserWithdrawalManager.sol";
-import "./interfaces/IStaderStakePoolManager.sol";
+import { UtilLib } from "./library/UtilLib.sol";
 
-import "@openzeppelin/contracts/utils/math/Math.sol";
-import "@openzeppelin/contracts/utils/math/SafeMath.sol";
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import { ETHx } from "./ETHx.sol";
+import { IPoolUtils } from "./interfaces/IPoolUtils.sol";
+import { IPoolSelector } from "./interfaces/IPoolSelector.sol";
+import { IStaderConfig } from "./interfaces/IStaderConfig.sol";
+import { IStaderOracle } from "./interfaces/IStaderOracle.sol";
+import { IStaderPoolBase } from "./interfaces/IStaderPoolBase.sol";
+import { IUserWithdrawalManager } from "./interfaces/IUserWithdrawalManager.sol";
+import { IStaderStakePoolManager } from "./interfaces/IStaderStakePoolManager.sol";
 
 /**
  *  @title Liquid Staking Pool Implementation

--- a/contracts/VaultProxy.sol
+++ b/contracts/VaultProxy.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "./library/UtilLib.sol";
-import "./interfaces/IVaultProxy.sol";
+import { UtilLib } from "./library/UtilLib.sol";
+import { IStaderConfig } from "./interfaces/IStaderConfig.sol";
+import { IVaultProxy } from "./interfaces/IVaultProxy.sol";
 
 //contract to delegate call to respective vault implementation based on the flag of 'isValidatorWithdrawalVault'
 contract VaultProxy is IVaultProxy {
@@ -40,6 +41,7 @@ contract VaultProxy is IVaultProxy {
         address vaultImplementation = isValidatorWithdrawalVault
             ? staderConfig.getValidatorWithdrawalVaultImplementation()
             : staderConfig.getNodeELRewardVaultImplementation();
+        // solhint-disable-next-line avoid-low-level-calls
         (bool success, bytes memory data) = vaultImplementation.delegatecall(_input);
         if (!success) {
             revert(string(data));

--- a/contracts/factory/VaultFactory.sol
+++ b/contracts/factory/VaultFactory.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "../library/UtilLib.sol";
-import "../VaultProxy.sol";
-import "../interfaces/IVaultFactory.sol";
-import "../interfaces/IStaderConfig.sol";
+import { ClonesUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/ClonesUpgradeable.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 
-import "@openzeppelin/contracts-upgradeable/proxy/ClonesUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { UtilLib } from "../library/UtilLib.sol";
+import { VaultProxy } from "../VaultProxy.sol";
+import { IVaultFactory } from "../interfaces/IVaultFactory.sol";
+import { IStaderConfig } from "../interfaces/IStaderConfig.sol";
 
 contract VaultFactory is IVaultFactory, AccessControlUpgradeable {
     IStaderConfig public staderConfig;

--- a/contracts/interfaces/INodeELRewardVault.sol
+++ b/contracts/interfaces/INodeELRewardVault.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "./IStaderConfig.sol";
-
 interface INodeELRewardVault {
     // errors
     error NotEnoughRewardToWithdraw();

--- a/contracts/interfaces/INodeRegistry.sol
+++ b/contracts/interfaces/INodeRegistry.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "../library/ValidatorStatus.sol";
+import { ValidatorStatus } from "../library/ValidatorStatus.sol";
 
 struct Validator {
     ValidatorStatus status; // status of validator

--- a/contracts/interfaces/IPermissionedNodeRegistry.sol
+++ b/contracts/interfaces/IPermissionedNodeRegistry.sol
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "../library/ValidatorStatus.sol";
-import "./INodeRegistry.sol";
-
 interface IPermissionedNodeRegistry {
     // Errors
     error NotAPermissionedNodeOperator();

--- a/contracts/interfaces/IPermissionlessNodeRegistry.sol
+++ b/contracts/interfaces/IPermissionlessNodeRegistry.sol
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "../library/ValidatorStatus.sol";
-import "./INodeRegistry.sol";
-
 interface IPermissionlessNodeRegistry {
     // Errors
     error TransferFailed();

--- a/contracts/interfaces/IPoolUtils.sol
+++ b/contracts/interfaces/IPoolUtils.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "./INodeRegistry.sol";
-
 // Interface for the PoolUtils contract
 interface IPoolUtils {
     // Errors

--- a/contracts/interfaces/ISDIncentiveController.sol
+++ b/contracts/interfaces/ISDIncentiveController.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "./IStaderConfig.sol";
-
 interface ISDIncentiveController {
     //errors
     error NoRewardsToClaim();

--- a/contracts/interfaces/ISocializingPool.sol
+++ b/contracts/interfaces/ISocializingPool.sol
@@ -2,7 +2,7 @@
 
 pragma solidity 0.8.16;
 
-import "./IStaderConfig.sol";
+import { IStaderConfig } from "./IStaderConfig.sol";
 
 /// @title RewardsData
 /// @notice This struct holds rewards merkleRoot and rewards split

--- a/contracts/interfaces/IStaderOracle.sol
+++ b/contracts/interfaces/IStaderOracle.sol
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "../library/ValidatorStatus.sol";
-
-import "./ISocializingPool.sol";
-import "./IStaderConfig.sol";
+import { IStaderConfig } from "./IStaderConfig.sol";
+import { RewardsData } from "./ISocializingPool.sol";
 
 struct SDPriceData {
     uint256 reportingBlockNumber;

--- a/contracts/interfaces/IStaderPoolBase.sol
+++ b/contracts/interfaces/IStaderPoolBase.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "./INodeRegistry.sol";
-
 interface IStaderPoolBase {
     // Errors
     error UnsupportedOperation();

--- a/contracts/interfaces/IValidatorWithdrawalVault.sol
+++ b/contracts/interfaces/IValidatorWithdrawalVault.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "./IStaderConfig.sol";
-
 interface IValidatorWithdrawalVault {
     // Errors
     error InvalidRewardAmount();

--- a/contracts/interfaces/IVaultProxy.sol
+++ b/contracts/interfaces/IVaultProxy.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "./IStaderConfig.sol";
+import { IStaderConfig } from "./IStaderConfig.sol";
 
 interface IVaultProxy {
     error CallerNotOwner();

--- a/contracts/interfaces/IWETH.sol
+++ b/contracts/interfaces/IWETH.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface IWETH is IERC20 {
     function deposit() external payable;

--- a/contracts/interfaces/SDCollateral/IAuction.sol
+++ b/contracts/interfaces/SDCollateral/IAuction.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "../IStaderConfig.sol";
+import { IStaderConfig } from "../IStaderConfig.sol";
 
 interface IAuction {
     // errors

--- a/contracts/interfaces/SDCollateral/ISDCollateral.sol
+++ b/contracts/interfaces/SDCollateral/ISDCollateral.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "../IStaderConfig.sol";
+import { IStaderConfig } from "../IStaderConfig.sol";
 
 interface ISDCollateral {
     struct PoolThresholdInfo {

--- a/contracts/library/UtilLib.sol
+++ b/contracts/library/UtilLib.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.16;
 
-import "../interfaces/IStaderConfig.sol";
-import "../interfaces/INodeRegistry.sol";
-import "../interfaces/IPoolUtils.sol";
-import "../interfaces/IVaultProxy.sol";
+import { IStaderConfig } from "../interfaces/IStaderConfig.sol";
+import { INodeRegistry } from "../interfaces/INodeRegistry.sol";
+import { IPoolUtils } from "../interfaces/IPoolUtils.sol";
+import { IVaultProxy } from "../interfaces/IVaultProxy.sol";
 
 library UtilLib {
     error ZeroAddress();

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "inquirer": "8.2.6",
         "prettier": "3.2.5",
         "prettier-plugin-solidity": "1.3.1",
-        "solhint": "^4.5.2",
+        "solhint": "5.0.1",
         "typechain": "^8.3.2"
       }
     },
@@ -12210,7 +12210,9 @@
       }
     },
     "node_modules/solhint": {
-      "version": "4.5.4",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/solhint/-/solhint-5.0.1.tgz",
+      "integrity": "sha512-QeQLS9HGCnIiibt+xiOa/+MuP7BWz9N7C5+Mj9pLHshdkNhuo3AzCpWmjfWVZBUuwIUO3YyCRVIcYLR3YOKGfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "forge test -v",
     "prettier:check": "prettier --check \"(contracts|test|script)/**/*.sol\"",
     "prettier:fix": "prettier --write \"(contracts|test|script)/**/*.sol\"",
-    "lint": "solhint 'contracts/**/*.sol' 'test/**/*.sol' 'script/**/*.sol'",
+    "lint": "solhint 'contracts/**/*.sol' 'script/**/*.sol'",
     "upgrade:arbitrum": "npx hardhat run scripts/safe-scripts/upgrade.ts --network arbitrum",
     "upgrade:playground:arbitrum": "npx hardhat run scripts/safe-scripts/upgradePlayground.ts --network arbitrum"
   },
@@ -37,7 +37,7 @@
     "inquirer": "8.2.6",
     "prettier": "3.2.5",
     "prettier-plugin-solidity": "1.3.1",
-    "solhint": "^4.5.2",
+    "solhint": "5.0.1",
     "typechain": "^8.3.2"
   },
   "dependencies": {

--- a/test/foundry_tests/PermissionedNodeRegistry.t.sol
+++ b/test/foundry_tests/PermissionedNodeRegistry.t.sol
@@ -19,7 +19,7 @@ import "../mocks/OperatorRewardsCollectorMock.sol";
 import "../mocks/PoolUtilsMockForDepositFlow.sol";
 
 import "forge-std/Test.sol";
-import "@openzeppelin/contracts/utils/math/Math.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 

--- a/test/foundry_tests/PermissionlessNodeRegistry.t.sol
+++ b/test/foundry_tests/PermissionlessNodeRegistry.t.sol
@@ -19,7 +19,7 @@ import "../mocks/OperatorRewardsCollectorMock.sol";
 import "../mocks/PoolUtilsMockForDepositFlow.sol";
 
 import "forge-std/Test.sol";
-import "@openzeppelin/contracts/utils/math/Math.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 

--- a/test/foundry_tests/SDUtilityPool.t.sol
+++ b/test/foundry_tests/SDUtilityPool.t.sol
@@ -14,7 +14,7 @@ import "../mocks/OperatorRewardsCollectorMock.sol";
 import "../mocks/PoolUtilsMock.sol";
 
 import "forge-std/Test.sol";
-import "@openzeppelin/contracts/utils/math/Math.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 

--- a/test/foundry_tests/StaderStakePoolManager.t.sol
+++ b/test/foundry_tests/StaderStakePoolManager.t.sol
@@ -10,7 +10,7 @@ import "../mocks/PoolUtilsMock.sol";
 import "../mocks/StaderOracleMock.sol";
 
 import "forge-std/Test.sol";
-import "@openzeppelin/contracts/utils/math/Math.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 


### PR DESCRIPTION
closes #238 

This cleans up many minor issues with imports.     All remaining lint warnings are invasive issues that should be considered on their own.