### PR TITLE
The amount of remaining delegate should exceed the minimum amount

### DIFF
--- a/contracts/SDUtilityPool.sol
+++ b/contracts/SDUtilityPool.sol
@@ -152,6 +152,10 @@ contract SDUtilityPool is ISDUtilityPool, AccessControlUpgradeable, PausableUpgr
         uint256 exchangeRate = _exchangeRateStored();
         delegatorCTokenBalance[msg.sender] -= _cTokenAmount;
         delegatorWithdrawRequestedCTokenCount[msg.sender] += _cTokenAmount;
+
+        if(delegatorCTokenBalance[msg.sender] * exchangeRate / DECIMAL < MIN_SD_DELEGATE_LIMIT)
+            revert InvalidInput();
+        
         uint256 sdRequested = (exchangeRate * _cTokenAmount) / DECIMAL;
         if (sdRequested < MIN_SD_WITHDRAW_LIMIT) {
             revert InvalidInput();

--- a/test/foundry_tests/SDUtilityPool.t.sol
+++ b/test/foundry_tests/SDUtilityPool.t.sol
@@ -849,4 +849,25 @@ contract SDUtilityPoolTest is Test {
         userData = sdUtilityPool.getUserData(operator);
         assertEq(0, userData.totalInterestSD);
     }
+    function test_leftOverCannotBeLessThanMinAmount() public {
+        address user = address(0xBAD);
+        deal(address(staderToken), staderAdmin, type(uint).max);
+        // Give tokens to participants
+        vm.prank(staderAdmin);
+        staderToken.transfer(user, 1_000_001e18);
+
+        vm.startPrank(user);
+        staderToken.approve(address(sdUtilityPool), 1e15);
+        sdUtilityPool.delegate(1e15);
+        
+        uint256 userCTokens = sdUtilityPool.delegatorCTokenBalance(user);
+        assertEq(userCTokens, 1e15);
+        vm.stopPrank();
+
+        vm.startPrank(user);
+        uint256 withdrawAmount = 1e15 - 1; // All but 1 wei
+        vm.expectRevert();
+        uint256 requestId = sdUtilityPool.requestWithdraw(withdrawAmount);
+
+    }
 }


### PR DESCRIPTION
Delegators are prohibited from delegating amounts below the `MIN_SD_DELEGATE_LIMIT`. Nonetheless, this limitation can be readily bypassed, as `SDUtilityPool::requestWithdraw` does not verify the remaining amount.